### PR TITLE
chore(flake/precommit): `3076ff29` -> `7ffbe4d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -230,11 +230,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1783710964,
-        "narHash": "sha256-Wlkb4KVuE16CSQ4XPtc4KGwf5KSp7LS7TWCXDicxtns=",
+        "lastModified": 1783875506,
+        "narHash": "sha256-Hx7uYdd6XyBohpAyIJwzjsJrUsY9ucOpzxoGMV+AYsI=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "3076ff29e23e52d8c3cd4c18d8ec086ed6ba8380",
+        "rev": "7ffbe4d244ef810e871ff616988753131c9595e8",
         "type": "github"
       },
       "original": {
@@ -297,11 +297,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1783663825,
-        "narHash": "sha256-TTrNVoFdEw8j0Hn+shP1KAsimTmszTWBIIUliTaAuY0=",
+        "lastModified": 1783834461,
+        "narHash": "sha256-FCmrs1StAghJDKfqy56KM96KZtxpYzgeq6zM3QO8wjA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "072adf9b18936c1062c48123a9b77891d5968f2c",
+        "rev": "a286e5b998e852297a403786f063fb2c9fe7f57a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`7ffbe4d2`](https://github.com/fredsystems/pre-commit-checks/commit/7ffbe4d244ef810e871ff616988753131c9595e8) | `` updates ``                                         |
| [`538e1735`](https://github.com/fredsystems/pre-commit-checks/commit/538e1735c9dc44bb8fc3bc2918a3a5618896a60d) | `` updates ``                                         |
| [`53d43fa0`](https://github.com/fredsystems/pre-commit-checks/commit/53d43fa05b4de2c1041d41a21d58efae2b674c59) | `` chore(flake/nixpkgs): 0bb7ec54 -> e7a3ca80 ``      |
| [`fc8d9b93`](https://github.com/fredsystems/pre-commit-checks/commit/fc8d9b9382519b7f1c256da05eebe82aa7aedfaf) | `` chore(flake/rust-overlay): 072adf9b -> a286e5b9 `` |