### PR TITLE
chore(flake/nixpkgs): `61b7c44c` -> `e2587cae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`47b388f4`](https://github.com/NixOS/nixpkgs/commit/47b388f4d31b0e068ebbcd2c829472cb47228cbc) | `` python3Packages.osmnx: 2.1.0 -> 2.1.1 ``                                                      |
| [`4958cbdb`](https://github.com/NixOS/nixpkgs/commit/4958cbdb484db669325e855df283a8436deb9d87) | `` caesura: 0.27.2 -> 0.31.0 ``                                                                  |
| [`0a43fea4`](https://github.com/NixOS/nixpkgs/commit/0a43fea4d70ec237aee8372fc3141e399a8cb947) | `` terraform-providers.yandex-cloud_yandex: 0.215.0 -> 0.218.0 ``                                |
| [`5fcb4c33`](https://github.com/NixOS/nixpkgs/commit/5fcb4c336ca07923c43d104d140176130c9f3651) | `` ku: 0.8.2 -> 0.9.0 ``                                                                         |
| [`70136603`](https://github.com/NixOS/nixpkgs/commit/70136603749761f5ed9ad652202bd35ab0ecb74d) | `` markdown-code-runner: 0.5.1 -> 0.5.2 ``                                                       |
| [`ec3b2759`](https://github.com/NixOS/nixpkgs/commit/ec3b2759fa48ed2efb45352967696f03f4fe1016) | `` vivliostyle: init at 11.1.0 ``                                                                |
| [`a6607790`](https://github.com/NixOS/nixpkgs/commit/a6607790accaf95ec90a8d90be361b84c8d916ee) | `` python3Packages.urllib3-future: 2.22.901 -> 2.23.900 ``                                       |
| [`d84e31bb`](https://github.com/NixOS/nixpkgs/commit/d84e31bba5d91726741e3fdddb61bf9e849509f8) | `` tenki: 1.11.0 -> 1.12.0 ``                                                                    |
| [`41185774`](https://github.com/NixOS/nixpkgs/commit/4118577436ddbf364af610a9473a9e4a66f44e0f) | `` python3Packages.mkdocs-awesome-nav: fix build ``                                              |
| [`4a016a84`](https://github.com/NixOS/nixpkgs/commit/4a016a844d74e07448705a7d25afbcf5540b3432) | `` gnome2.gnome_mime_data: drop ``                                                               |
| [`9fc2979d`](https://github.com/NixOS/nixpkgs/commit/9fc2979d56200ce947789aea6663b1f265ad9ffe) | `` python3Packages.frictionless: switch to pytest 9.0 ``                                         |
| [`a7feaef3`](https://github.com/NixOS/nixpkgs/commit/a7feaef329adccfc3396fc2b5b5af969ec8a05f8) | `` home-assistant-custom-lovelace-modules.material-you-utilities: 2.1.19 -> 2.1.20 ``            |
| [`142d0347`](https://github.com/NixOS/nixpkgs/commit/142d03479737853868e82aed215bd0b4e273b552) | `` egctl: 1.8.2 -> 1.8.3 ``                                                                      |
| [`3af3af66`](https://github.com/NixOS/nixpkgs/commit/3af3af6612ce52c659a0f9bdf234a1c788060044) | `` home-assistant-custom-components.dreo: 1.10.5 -> 1.10.6 ``                                    |
| [`a9a8e1ca`](https://github.com/NixOS/nixpkgs/commit/a9a8e1ca27001420844aead107515facf6b2118c) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.83.10 -> 1.83.13 ``                     |
| [`00d4b4e5`](https://github.com/NixOS/nixpkgs/commit/00d4b4e573d53c2b57afeba67fa21ab70d2d5ee7) | `` Revert "python3Packages.starsessions: 2.2.1 -> .2.2.0" ``                                     |
| [`fa33c15b`](https://github.com/NixOS/nixpkgs/commit/fa33c15b8e19ecfce664f280f209f938fc9684cb) | `` vimPlugins.blink-pairs: 0.5.0 -> 0.6.0 ``                                                     |
| [`537df83f`](https://github.com/NixOS/nixpkgs/commit/537df83fd529b4df90b1e53d77c23faef091f7c4) | `` vimPlugins.blink-pairs: add saadndm as maintainer ``                                          |
| [`c2a681da`](https://github.com/NixOS/nixpkgs/commit/c2a681da35a0b1b790f6d1a7c3fbee75cff209d7) | `` python3Packages.pydantic-ai-slim: allow nixpkgs-update to commit update ``                    |
| [`e9b15707`](https://github.com/NixOS/nixpkgs/commit/e9b15707397b063149b6791ad7ab99332c19bd8e) | `` arcanist: restore, on new upstream, in by-name form ``                                        |
| [`62993a3a`](https://github.com/NixOS/nixpkgs/commit/62993a3a8f583cc5e1b3eabb48cf7cc64de67ee2) | `` pomo: init at 1.2.1 ``                                                                        |
| [`a0bf208c`](https://github.com/NixOS/nixpkgs/commit/a0bf208c7423c2e5e8a332c609879c2ea59cc889) | `` libsolv: 0.7.37 -> 0.7.39 ``                                                                  |
| [`823e0452`](https://github.com/NixOS/nixpkgs/commit/823e04528e2a869bbaa4e6d9056ad23a5b83fe91) | `` spotdl: 4.5.0 -> 4.5.2 ``                                                                     |
| [`48e9eca4`](https://github.com/NixOS/nixpkgs/commit/48e9eca41f314eba0d496662f5f3a71073ad9ba0) | `` sideband: remove obsolete `replace-fail` ``                                                   |
| [`5c649291`](https://github.com/NixOS/nixpkgs/commit/5c649291c90255bcfa291536dae167a8207534e7) | `` libretro.pcsx2: 0-unstable-2026-06-29 -> 0-unstable-2026-07-20 ``                             |
| [`9d61dbc5`](https://github.com/NixOS/nixpkgs/commit/9d61dbc566cee045bb696e6d971cb20e2534c6da) | `` terraform-providers.e-breuninger_netbox: 5.6.2 -> 5.7.0 ``                                    |
| [`7a41b6b3`](https://github.com/NixOS/nixpkgs/commit/7a41b6b3d7b13aada44a4f907c7216084c85eaa7) | `` opkssh: 0.15.0 -> 0.16.0 ``                                                                   |
| [`5910e1cf`](https://github.com/NixOS/nixpkgs/commit/5910e1cf0efa0897f7a87adea03ff887550a320c) | `` sideband: use `python313Packages` ``                                                          |
| [`487ed283`](https://github.com/NixOS/nixpkgs/commit/487ed283b17774bfdad74976c4e9e9acbd3fa575) | `` hacompanion: 1.0.30 -> 1.1.0 ``                                                               |
| [`fe53ec45`](https://github.com/NixOS/nixpkgs/commit/fe53ec45254fee0c087526be01f8e80cca98c24b) | `` terraform-providers.aminueza_minio: 3.38.3 -> 3.38.5 ``                                       |
| [`0a9d0fe3`](https://github.com/NixOS/nixpkgs/commit/0a9d0fe378a074d280c1311c1c1c57fa229834a8) | `` terraform-providers.hetznercloud_hcloud: 1.66.0 -> 1.66.1 ``                                  |
| [`5d8bdfe9`](https://github.com/NixOS/nixpkgs/commit/5d8bdfe9c8add4a0f722f1110d2ea18a4e01bf0a) | `` lightningcss: 1.32.0 -> 1.33.0 ``                                                             |
| [`4898a410`](https://github.com/NixOS/nixpkgs/commit/4898a4107d78433826566e927dfc7fb18481ec50) | `` cargo-readme: transfer maintainership ``                                                      |
| [`700f592f`](https://github.com/NixOS/nixpkgs/commit/700f592f4b6a8472f131b7f4e8879e59084e2f7e) | `` lux-cli: 0.36.1 -> 0.39.1 ``                                                                  |
| [`f993ce2f`](https://github.com/NixOS/nixpkgs/commit/f993ce2ffd052cb5f63594b02ac8c7aa74dd7c67) | `` nixos/auditd: fix mkEnableOption description ``                                               |
| [`42586aae`](https://github.com/NixOS/nixpkgs/commit/42586aaeb2cdffb6c9023c5766b6874b1e4bc0df) | `` nixos/corefreq: fix mkEnableOption description ``                                             |
| [`2b4eb507`](https://github.com/NixOS/nixpkgs/commit/2b4eb507f4a13d65360480248b905a923fd976dc) | `` terraform-providers.drfaust92_bitbucket: 2.51.0 -> 2.52.0 ``                                  |
| [`e7a98248`](https://github.com/NixOS/nixpkgs/commit/e7a98248f5ba18bb1ec90872ed9cb7819ead0244) | `` wsjtz: 2.0.16 -> 2.0.18, fix desktopitem to avoid against wsjtx ``                            |
| [`adc88786`](https://github.com/NixOS/nixpkgs/commit/adc88786a16772b7a36e1c057222eee8b1845cee) | `` bat: fix escaping of shell settings values ``                                                 |
| [`3b94d36d`](https://github.com/NixOS/nixpkgs/commit/3b94d36d7d41a57d9e35a79252d598ca17b3d716) | `` nixos/containers: new registries.settings option, deprecate others ``                         |
| [`a8340d64`](https://github.com/NixOS/nixpkgs/commit/a8340d6475f7cc6003d2aa9b634bb1c163529ef4) | `` devin-cli: 3000.1.27 -> 3000.2.17 ``                                                          |
| [`d6d0c1a3`](https://github.com/NixOS/nixpkgs/commit/d6d0c1a3a42e5d56ba5065945a7351f99b8a7ffc) | `` haskellPackages: regenerate hackage packages after cwiid drop ``                              |
| [`ab07aeec`](https://github.com/NixOS/nixpkgs/commit/ab07aeec5809056a4d3b2fdc5d3537cccefad013) | `` cwiid: drop ``                                                                                |
| [`5648ac43`](https://github.com/NixOS/nixpkgs/commit/5648ac435198d18cac88b0c9e7eaf097b8aaa4c1) | `` kodi: don't build with cwiid for wiiremote support ``                                         |
| [`289ee591`](https://github.com/NixOS/nixpkgs/commit/289ee59179cb517d2af0728519bb831b007774fc) | `` openbao: 2.6.0 -> 2.6.1 ``                                                                    |
| [`3b4a2f55`](https://github.com/NixOS/nixpkgs/commit/3b4a2f55332acb6c0a65bd8b2d3ff3004dcd7163) | `` smpeg: drop gtk2 and opengl player ``                                                         |
| [`82d4f5b3`](https://github.com/NixOS/nixpkgs/commit/82d4f5b39f810275d0758d6266fc9427d981e0cd) | `` python3Packages.pyglet: replace gtk2 usage with pillow ``                                     |
| [`49aad6bc`](https://github.com/NixOS/nixpkgs/commit/49aad6bcb7e4541cf8f0358c80389c9edde3c426) | `` gotlsaflare: 2.8.3 -> 2.8.4 ``                                                                |
| [`6aa8cdea`](https://github.com/NixOS/nixpkgs/commit/6aa8cdeae4e8d7a34261c293b7cde3cea44a98c7) | `` terraform-providers.hashicorp_aws: 6.54.0 -> 6.55.0 ``                                        |
| [`392ae092`](https://github.com/NixOS/nixpkgs/commit/392ae092e65dba70d9af864efd6ac3f485cde9af) | `` schemat: 0.5.2 -> 0.5.3 ``                                                                    |
| [`eab52df2`](https://github.com/NixOS/nixpkgs/commit/eab52df2790bd4eb73942b8ce63174710b6c27b6) | `` chromium,chromedriver: 150.0.7871.128 -> 150.0.7871.181 ``                                    |
| [`6b51ea18`](https://github.com/NixOS/nixpkgs/commit/6b51ea181fd2ad4c4d21a2e11565906cfd9980ad) | `` orion: remove ``                                                                              |
| [`65a1f405`](https://github.com/NixOS/nixpkgs/commit/65a1f405690ab5467a6c71e18fd520f37d371bfd) | `` python3Packages.simple-parsing: remove wrong orion test dep ``                                |
| [`8fd082ce`](https://github.com/NixOS/nixpkgs/commit/8fd082ce8a5277e53529555a66b9955c54689e7f) | `` docker-credential-env: 1.6.1 -> 1.7.0 ``                                                      |
| [`24573642`](https://github.com/NixOS/nixpkgs/commit/24573642611b3e468eb5c6dbdcafb047dda3927a) | `` dolt: 2.2.1 -> 2.2.2 ``                                                                       |
| [`06bafd30`](https://github.com/NixOS/nixpkgs/commit/06bafd3066b731842a8f19d8c6deb493a4184c73) | `` ocamlPackages.ca-certs-nss: 3.125 -> 3.126 ``                                                 |
| [`edd52f2c`](https://github.com/NixOS/nixpkgs/commit/edd52f2cbdb5b22909d424b300d754117e68a3c0) | `` vja: 5.3.0 -> 5.4.2 ``                                                                        |
| [`eef8c623`](https://github.com/NixOS/nixpkgs/commit/eef8c6234d05651086003bd97f8a934bed9a90a9) | `` switchfin: 0.9.1 -> 0.9.2 ``                                                                  |
| [`a90eb285`](https://github.com/NixOS/nixpkgs/commit/a90eb28543d35394a5fbca0fed700dbfd8b85a58) | `` pvetui: 1.4.2 -> 1.4.3 ``                                                                     |
| [`54769f33`](https://github.com/NixOS/nixpkgs/commit/54769f3399e81208ea1a6517bce984085d2ea9b9) | `` sourcey: init at 3.6.5 ``                                                                     |
| [`f8300dea`](https://github.com/NixOS/nixpkgs/commit/f8300dea948997b06fbb10b300e4af08d87c737a) | `` putzen: 3.3.2 -> 3.3.3 ``                                                                     |
| [`d8242388`](https://github.com/NixOS/nixpkgs/commit/d8242388cbe18e762fae7014d83506836f05ecfa) | `` radicle-node-unstable: 1.10.0-rc.1 -> 1.10.0-rc.2 ``                                          |
| [`aaab691b`](https://github.com/NixOS/nixpkgs/commit/aaab691bbeffe419ee32e9d01ab2a95df8fe3c89) | `` dn42-registry-wizard: 0.4.20 -> 0.4.21 ``                                                     |
| [`1cfcb264`](https://github.com/NixOS/nixpkgs/commit/1cfcb264389f53a9a2b32e712f07465aae422338) | `` olivetin-3k: 3000.17.0 -> 3000.17.3 ``                                                        |
| [`f57e9ddd`](https://github.com/NixOS/nixpkgs/commit/f57e9dddb69e5aa83c6038177aa8c83831a1c0b0) | `` paperwork: fix build with recent versions of setuptools ``                                    |
| [`47388b76`](https://github.com/NixOS/nixpkgs/commit/47388b760aca5ee7485b2fe9e4eee07fc3440411) | `` sprite: 0.0.1-rc45 -> 0.0.1-rc46 ``                                                           |
| [`6f3401e7`](https://github.com/NixOS/nixpkgs/commit/6f3401e7e1f14c466fdcd27f71f1c6f9e8660f59) | `` home-assistant.python3Packages.pytest-homeassistant-custom-component: 0.13.346 -> 0.13.347 `` |
| [`36a72f6f`](https://github.com/NixOS/nixpkgs/commit/36a72f6f004f66a31d2b7ce38eae7ea130339d6e) | `` nixos/tests/installer: add grubCryptodiskLegacyBios and unbreak fullDiskEncryption ``         |
| [`889571cf`](https://github.com/NixOS/nixpkgs/commit/889571cf97316f87b75a3c67bb3ce3fb9cc1ba80) | `` nixos/tests/grub: split into a directory and expand coverage ``                               |
| [`ec583636`](https://github.com/NixOS/nixpkgs/commit/ec5836368941c7fc54664c734d5a66688540fca3) | `` gitlab: 18.11.6 -> 18.11.7 ``                                                                 |
| [`5d4dccf4`](https://github.com/NixOS/nixpkgs/commit/5d4dccf4149116534ee0ffec82c07239e8142506) | `` rattler-build: 0.68.0 -> 0.70.0 ``                                                            |
| [`4933b592`](https://github.com/NixOS/nixpkgs/commit/4933b592f622d5243bfe967880fa5ab80223654d) | `` python3Packages.uiprotect: 15.12.2 -> 15.14.2 ``                                              |
| [`d1d9dc2a`](https://github.com/NixOS/nixpkgs/commit/d1d9dc2a1ad821d893fdbb4ca35025d5371991a2) | `` spruce: 1.35.11 -> 1.35.13 ``                                                                 |
| [`f448d919`](https://github.com/NixOS/nixpkgs/commit/f448d919d745490ce942dea9f94f6030ca8b41f9) | `` python3Packages.runtype: init at version 0.5.3 ``                                             |
| [`a2a9084d`](https://github.com/NixOS/nixpkgs/commit/a2a9084d4497f0c4d00306b9e8f4e9cb069b32bc) | `` maintainers: add BrockoliniMorgan ``                                                          |
| [`b2cb632c`](https://github.com/NixOS/nixpkgs/commit/b2cb632cb181b534a274f3ad806daddb67f49847) | `` python3Packages.ha-garmin: 0.1.29 -> 0.1.31 ``                                                |
| [`0c2857e4`](https://github.com/NixOS/nixpkgs/commit/0c2857e469eadde05ad0c009cd89614b19cf6e2d) | `` knot-resolver_5: 5.7.6 -> 5.7.7 (security!) ``                                                |
| [`59d6f14e`](https://github.com/NixOS/nixpkgs/commit/59d6f14e97a7f43658b74112bc18976f4e91aa6b) | `` knot-resolver_6: 6.4.0 -> 6.4.1 (security!) ``                                                |
| [`f0ca40c9`](https://github.com/NixOS/nixpkgs/commit/f0ca40c94f827317535e92a68e792c35296f8e3c) | `` wakatime-cli: 2.15.0 -> 2.22.2 ``                                                             |
| [`8574ae1a`](https://github.com/NixOS/nixpkgs/commit/8574ae1a413ac8e6433a1049b931fb69b5b265de) | `` igsc: 1.3.0 -> 1.3.1 ``                                                                       |
| [`4b0c1fbb`](https://github.com/NixOS/nixpkgs/commit/4b0c1fbb12618d8cc2568a7a59c3adca8a037806) | `` wowup-cf: 2.22.0 -> 2.23.0 ``                                                                 |
| [`d0693049`](https://github.com/NixOS/nixpkgs/commit/d069304953f6d29285e48ffb3bbde67774915a2a) | `` matrix-tuwunel: 1.8.1 -> 1.8.2 ``                                                             |
| [`60f46db5`](https://github.com/NixOS/nixpkgs/commit/60f46db56951155a06ba46fcf8fdb3985f5a02a4) | `` git-spice: 0.31.1 -> 0.31.2 ``                                                                |
| [`df098033`](https://github.com/NixOS/nixpkgs/commit/df098033640fe1352fe8244a5574ea9fce15724f) | `` offpunk: 3.1 -> 3.2 ``                                                                        |
| [`d6830397`](https://github.com/NixOS/nixpkgs/commit/d6830397b3983f86b8ffe1c3bfb549b036eed476) | `` gelly: 1.9.2 -> 1.9.4 ``                                                                      |
| [`e8f3271c`](https://github.com/NixOS/nixpkgs/commit/e8f3271c6d1cba862774de6451af5331f833edc4) | `` python3Packages.lxst: 0.4.4 -> 0.5.0 ``                                                       |
| [`82b8c865`](https://github.com/NixOS/nixpkgs/commit/82b8c86508f043c40083d84304ba5ade334b8af2) | `` python3Packages.kafka-python: 3.0.8 -> 3.0.9 ``                                               |
| [`4165703b`](https://github.com/NixOS/nixpkgs/commit/4165703b83a914114f1d2b6dddb3f6566df91375) | `` vimPlugins.blink-lib: init at 0-unstable-2026-06-19 ``                                        |
| [`b4a424fb`](https://github.com/NixOS/nixpkgs/commit/b4a424fb29227237e20ff8fd969e16a41be5580b) | `` sideband: 1.9.8 -> 2.0.0 ``                                                                   |
| [`a0c6b7f0`](https://github.com/NixOS/nixpkgs/commit/a0c6b7f034a4120d98304ea63dc5923b2aefaa78) | `` cargo-readme: add sshine as maintainer ``                                                     |
| [`cb1cdb2b`](https://github.com/NixOS/nixpkgs/commit/cb1cdb2b01ea570bbf14b3740a765af38b9b9571) | `` python313Packages.pyexploitdb: 0.3.35 -> 0.3.36 ``                                            |
| [`35a6ed30`](https://github.com/NixOS/nixpkgs/commit/35a6ed3041cc76d5d2f35ea325f91d10f1ffe930) | `` nocturne: 1.4.0 -> 1.4.2 ``                                                                   |
| [`44ab10a9`](https://github.com/NixOS/nixpkgs/commit/44ab10a93c9f22750e8169f9df9825f626f563d3) | `` python313Packages.publicsuffixlist: 1.0.2.20260715 -> 1.0.2.20260722 ``                       |
| [`6f4867d8`](https://github.com/NixOS/nixpkgs/commit/6f4867d884db5c1bb47d3c4337d10a9fedd98498) | `` python313Packages.iamdata: 0.1.202607211 -> 0.1.202607221 ``                                  |
| [`58a2e2f9`](https://github.com/NixOS/nixpkgs/commit/58a2e2f971cf9ada3a4fbe5ffc8551ea413cbfe0) | `` jwtcat: init at 0-unstable-2022-10-15 ``                                                      |
| [`b14f8fbb`](https://github.com/NixOS/nixpkgs/commit/b14f8fbb74ac8fa347b154e9d6fcb9e04e9329c4) | `` maintainers: add _0x2B-bin ``                                                                 |
| [`7c98713f`](https://github.com/NixOS/nixpkgs/commit/7c98713fc160563c84e3d36331029baf17246878) | `` python3Packages.homeassistant-stubs: 2026.7.2 -> 2026.7.3 ``                                  |
| [`05ab63fc`](https://github.com/NixOS/nixpkgs/commit/05ab63fcd91bba22746165b07aecff1956fca73a) | `` libretro.dosbox-pure: 0-unstable-2026-07-06 -> 0-unstable-2026-07-15 ``                       |
| [`b09c4468`](https://github.com/NixOS/nixpkgs/commit/b09c4468715107965236efe55183324aabd4dd50) | `` monero-gui: 0.18.5.0 -> 0.18.5.2 ``                                                           |
| [`dd3694e5`](https://github.com/NixOS/nixpkgs/commit/dd3694e504d74db0d394c402e41da4ff8c6892bb) | `` monero-cli: 0.18.5.0 -> 0.18.5.1 ``                                                           |
| [`ddcc9d5a`](https://github.com/NixOS/nixpkgs/commit/ddcc9d5afe493321dd96f1da455b6fc888ab7acf) | `` randomx: 1.2.1 -> 1.2.2 ``                                                                    |
| [`b09733d3`](https://github.com/NixOS/nixpkgs/commit/b09733d369efaded7ffef6cce82fb65c03441595) | `` dnsdiag: 2.9.3 -> 2.9.4 ``                                                                    |
| [`8d29261d`](https://github.com/NixOS/nixpkgs/commit/8d29261d941720d7dec8d9da8550c81f528fa5ac) | `` vscode-extensions.anthropic.claude-code: 2.1.216 -> 2.1.217 ``                                |
| [`539df813`](https://github.com/NixOS/nixpkgs/commit/539df81347e74a49b3ea173d65781a89371cec53) | `` claude-code: 2.1.216 -> 2.1.217 ``                                                            |
| [`6138d2d5`](https://github.com/NixOS/nixpkgs/commit/6138d2d546fd2a81232d7161c3714ff2605378f0) | `` python3Packages.py3status: 3.63 -> 3.64 ``                                                    |
| [`668989a1`](https://github.com/NixOS/nixpkgs/commit/668989a1c82d7a1884411e2627591201e10068cf) | `` vault-ssh-plus: 0.7.9 -> 0.8.0 ``                                                             |
| [`0e1aa5a7`](https://github.com/NixOS/nixpkgs/commit/0e1aa5a74456fb4efb55cd98ca276df36e091471) | `` javaPackages.compiler.openjdk17: 17.0.20+2 -> 17.0.20+8 ``                                    |
| [`bdf9afc6`](https://github.com/NixOS/nixpkgs/commit/bdf9afc623fa3bbde84437bcfb39f964fa3f9b31) | `` python3Packages.sabctools: 9.6.1 -> 9.6.2 ``                                                  |
| [`7fe79f3d`](https://github.com/NixOS/nixpkgs/commit/7fe79f3d01021235b23b315f70535a7a1129ccb1) | `` claude-agent-acp: 0.58.1 -> 0.60.0 ``                                                         |
| [`164dd56a`](https://github.com/NixOS/nixpkgs/commit/164dd56a60167cda255144d0a86a64941558d218) | `` sioyek: 2.0.0-unstable-2026-07-11 -> 2.0.0-unstable-2026-07-21 ``                             |
| [`dbdb6366`](https://github.com/NixOS/nixpkgs/commit/dbdb6366520d81177b58b86f2ef72333dea61910) | `` vscode-extensions.tuttieee.emacs-mcx: 0.110.11 -> 0.111.0 ``                                  |
| [`469aba3b`](https://github.com/NixOS/nixpkgs/commit/469aba3b91087c5595825faf76a0323c0cdc5c5f) | `` python3Packages.types-aiobotocore: 3.7.0 -> 3.8.0 ``                                          |
| [`0efbc130`](https://github.com/NixOS/nixpkgs/commit/0efbc1300ee20144e7755c6ab5d25495f82ca52c) | `` hunk: 0.17.0 -> 0.17.3 ``                                                                     |
| [`a4f06340`](https://github.com/NixOS/nixpkgs/commit/a4f0634015c5b0d64b431171cf2d068ff0a0a4fb) | `` grafanaPlugins.grafana-metricsdrilldown-app: 2.2.0 -> 2.3.0 ``                                |
| [`0f5d8c33`](https://github.com/NixOS/nixpkgs/commit/0f5d8c33645fdc533f1a74538f16888d138993af) | `` python3Packages.materialyoucolor: 3.0.2 -> 3.0.3 ``                                           |
| [`4d213715`](https://github.com/NixOS/nixpkgs/commit/4d2137156a3f5832b93341533557d43023f99d38) | `` libretro.gambatte: 0-unstable-2026-07-03 -> 0-unstable-2026-07-17 ``                          |
| [`c36286be`](https://github.com/NixOS/nixpkgs/commit/c36286be13d652e0527a08549d01b7b383a0fcae) | `` runpodctl: 2.6.1 -> 2.7.2 ``                                                                  |
| [`1fe77c95`](https://github.com/NixOS/nixpkgs/commit/1fe77c95b1f10ba3a315d1617d58404045c19f5e) | `` nezha: 2.2.10 -> 2.3.0 ``                                                                     |
| [`e0990a2f`](https://github.com/NixOS/nixpkgs/commit/e0990a2f95ae0ce4ecc41badf459fb70d92549cc) | `` nerdfetch: 8.5.4 -> 8.5.5 ``                                                                  |
| [`aec5dcbd`](https://github.com/NixOS/nixpkgs/commit/aec5dcbd7a3b58fab0257feeab4f5f30ceb7e2a4) | `` freecad: 1.1 fix sheetmetal workbench addon ``                                                |
| [`7f2da58a`](https://github.com/NixOS/nixpkgs/commit/7f2da58ad7b59bb6a5e9a309b15701f0bc5b5e2e) | `` libretro.swanstation: 0-unstable-2026-06-25 -> 0-unstable-2026-07-20 ``                       |
| [`303d5123`](https://github.com/NixOS/nixpkgs/commit/303d51235e5aeb71fb15fd15dae3f6585d22acfa) | `` snx-rs: 6.2.0 -> 6.2.1 ``                                                                     |
| [`66487b4c`](https://github.com/NixOS/nixpkgs/commit/66487b4c7179bd21098f6598fb03afc2ce0873f8) | `` skim: 5.1.0 -> 5.4.0 ``                                                                       |
| [`88ebd9f5`](https://github.com/NixOS/nixpkgs/commit/88ebd9f5ec4bddf28180c2a5441d25ec95cfeba1) | `` cider: drop ``                                                                                |
| [`62d4d822`](https://github.com/NixOS/nixpkgs/commit/62d4d822fad0abf0e10431ddf5fc70ce22826c02) | `` hyprsunset: 0.3.3 -> 0.4.0 ``                                                                 |
| [`20af6dcf`](https://github.com/NixOS/nixpkgs/commit/20af6dcfebe20da52e5696b0b8640af315f86b5a) | `` prometheus-knot-exporter: 3.5.5 -> 3.5.6 ``                                                   |
| [`51e22711`](https://github.com/NixOS/nixpkgs/commit/51e22711cf7f9e83d2ef28e0135516ff574c84a3) | `` libretro.vba-next: 0-unstable-2026-06-29 -> 0-unstable-2026-07-21 ``                          |
| [`81c5f784`](https://github.com/NixOS/nixpkgs/commit/81c5f78474a20d6c3ece233231ef9ca6069118b9) | `` home-assistant-custom-components.systemair: 1.0.29 -> 1.0.35 ``                               |
| [`15abc69c`](https://github.com/NixOS/nixpkgs/commit/15abc69c9100ca8bd27aa2a1ce2557af185fe891) | `` home-assistant-custom-components.dreo: 1.10.1 -> 1.10.5 ``                                    |
| [`57be2153`](https://github.com/NixOS/nixpkgs/commit/57be21539ce7dc7ef0b6239bb94ce6b194d101a6) | `` wxmaxima: 26.07.0 -> 26.07.1 ``                                                               |
| [`3deba723`](https://github.com/NixOS/nixpkgs/commit/3deba7238772757b52120b576e16b6780cd545d7) | `` radicle-explorer: 0-unstable-2026-07-16 -> 0-unstable-2026-07-21 ``                           |
| [`fa67cb5f`](https://github.com/NixOS/nixpkgs/commit/fa67cb5f409b9320936c1f967bafed5d290b4bb2) | `` home-assistant-custom-components.octopus_energy: pin pytest 9.0.x ``                          |
| [`3655ed91`](https://github.com/NixOS/nixpkgs/commit/3655ed910f10bae02be18859d7442f13614b2ed5) | `` home-assistant-custom-components.systemair: pin pytest 9.0.x ``                               |
| [`91df1e76`](https://github.com/NixOS/nixpkgs/commit/91df1e76f2b105f6f7c429b0a8a55730a83aac35) | `` home-assistant-custom-components.dreo: pin pytest 9.0.x ``                                    |
| [`64f84aeb`](https://github.com/NixOS/nixpkgs/commit/64f84aeb974079e9a0f96f86185317d203069707) | `` inferno: 0.12.6 -> 0.12.8 ``                                                                  |
| [`5e43461c`](https://github.com/NixOS/nixpkgs/commit/5e43461c4016de1cb08b39b0a0b3790121615a51) | `` python3Packages.aionut: pin pytest 9.0.x ``                                                   |
| [`0603d5a4`](https://github.com/NixOS/nixpkgs/commit/0603d5a452d8591e957a137e7ecd5a4112b62eba) | `` python3Packages.aio-geojson-usgs-earthquakes: fix src hash ``                                 |
| [`473de81b`](https://github.com/NixOS/nixpkgs/commit/473de81bcd17179aa71fd5349e6c6eebb0924c35) | `` python3Packages.pysmhi: fix version in pyproject.toml ``                                      |
| [`e8b8cfd2`](https://github.com/NixOS/nixpkgs/commit/e8b8cfd2f40de47d88f84ec8f06ffce9344a2ee1) | `` python3Packages.pydantic-graph: disable nixpkgs-update ``                                     |
| [`1682138b`](https://github.com/NixOS/nixpkgs/commit/1682138b38c8107f778bc64601224f0cab0d7d49) | `` stremio-linux-shell: 1.1.2 -> 1.1.3 ``                                                        |
| [`637e62e9`](https://github.com/NixOS/nixpkgs/commit/637e62e9aa53d59d07c54e17becfd05978f35535) | `` python3Packages.deebot-client: fix version in pyproject.toml ``                               |
| [`96b06163`](https://github.com/NixOS/nixpkgs/commit/96b06163bdfb7277fb3b72ed2235ca28995a145e) | `` python3Packages.nextdns: fix version in pyproject.toml ``                                     |
| [`e298d254`](https://github.com/NixOS/nixpkgs/commit/e298d254a4bceb1b43a922386fcf5f3495a4b933) | `` google-chrome: 150.0.7871.128 -> 150.0.7871.181 ``                                            |
| [`ce2f48f3`](https://github.com/NixOS/nixpkgs/commit/ce2f48f3909125197934826c5384368853f2ae8e) | `` javaPackages.compiler.openjdk25: 25.0.4+1 -> 25.0.4+7 ``                                      |
| [`c9f0136e`](https://github.com/NixOS/nixpkgs/commit/c9f0136e590b6113909e9127163d386107171bcb) | `` python3Packages.pydantic-ai-slim: add update script ``                                        |
| [`9bb81748`](https://github.com/NixOS/nixpkgs/commit/9bb81748f821cd550fa3c6be6a5bd7d1d10365e9) | `` home-assistant-custom-lovelace-modules.horizon-card: 1.5.0 -> 1.5.3 ``                        |
| [`27198f3b`](https://github.com/NixOS/nixpkgs/commit/27198f3b937d7d39bdf85a7c4091abb726210316) | `` home-assistant-custom-lovelace-modules.custom-sidebar: 16.0.0 -> 16.1.0 ``                    |
| [`b40c6aaf`](https://github.com/NixOS/nixpkgs/commit/b40c6aaf31dafbde08afcd183a23261fc508162b) | `` home-assistant-custom-lovelace-modules.custom-brand-icons: 2026.07.1 -> 2026.07.3 ``          |
| [`349c843e`](https://github.com/NixOS/nixpkgs/commit/349c843e0ffff5b77968e3196e576cc82b35b964) | `` home-assistant-custom-lovelace-modules.clock-weather-card: 2.9.2 -> 2.9.4 ``                  |
| [`38f27426`](https://github.com/NixOS/nixpkgs/commit/38f27426956e20c952b5162d1052b64299499838) | `` home-assistant-custom-lovelace-modules.bubble-card: 3.2.4 -> 3.2.5 ``                         |
| [`019f7a50`](https://github.com/NixOS/nixpkgs/commit/019f7a5033013145bedf623011d6b1683455669d) | `` home-assistant-custom-components.waste_collection_schedule: 2.30.0 -> 2.31.1 ``               |
| [`4d943cda`](https://github.com/NixOS/nixpkgs/commit/4d943cda2acc81daabb60233ee7fc130a0d77574) | `` home-assistant-custom-components.tuya_local: 2026.7.1 -> 2026.7.2 ``                          |
| [`ce15d8fe`](https://github.com/NixOS/nixpkgs/commit/ce15d8fe581557eee6496c87cefde1041dee2ca2) | `` home-assistant-custom-components.tibber_local: 2026.6.2 -> 2026.7.0 ``                        |
| [`12e35fd4`](https://github.com/NixOS/nixpkgs/commit/12e35fd42de31bb1821593793c2797c356eabdbf) | `` home-assistant-custom-components.sensi: 2.1.4 -> 2.1.5 ``                                     |
| [`6a93e7a9`](https://github.com/NixOS/nixpkgs/commit/6a93e7a951f59c48e9b9a611409d7bb17dc37ed3) | `` home-assistant-custom-components.scene_presets: 2.3.2 -> 2.3.3 ``                             |
| [`2ce9e697`](https://github.com/NixOS/nixpkgs/commit/2ce9e6975e2d869abcaaa94c153cdf0390c2c84f) | `` home-assistant-custom-components.prometheus_sensor: 1.3.0 -> 1.3.1 ``                         |
| [`a6ddfa5b`](https://github.com/NixOS/nixpkgs/commit/a6ddfa5b36cfe1e495ffed6f494b0fe6b4930d1a) | `` home-assistant-custom-components.powercalc: 1.22.0 -> 1.23.0 ``                               |
| [`eb973e81`](https://github.com/NixOS/nixpkgs/commit/eb973e811789f9e08d687667575d021b0255a476) | `` home-assistant-custom-components.pirate-weather: 1.8.9 -> 1.9.0 ``                            |
| [`678578b4`](https://github.com/NixOS/nixpkgs/commit/678578b4727aa3ac2c0a453163de9f4899c3f0b4) | `` home-assistant-custom-components.mypyllant: 0.9.17 -> 0.9.18 ``                               |
| [`d3795b4c`](https://github.com/NixOS/nixpkgs/commit/d3795b4cbdd7b557c56362001b12a2717d40d38e) | `` python3Packages.mypyllant: 0.9.16 -> 0.9.17 ``                                                |
| [`0b30785a`](https://github.com/NixOS/nixpkgs/commit/0b30785a4d31f39acac8651214df9fff7558b70a) | `` home-assistant-custom-components.midea_ac: 2026.7.0 -> 2026.7.1 ``                            |
| [`73584e8c`](https://github.com/NixOS/nixpkgs/commit/73584e8c9b873f9a2ccc5e2a325e7e6a62f483c1) | `` home-assistant-custom-components.garmin_connect: 3.0.13 -> 3.0.14 ``                          |
| [`790766ef`](https://github.com/NixOS/nixpkgs/commit/790766efec072835242f10ecb79ead7cb2fe9873) | `` home-assistant-custom-components.frigidaire: 0.1.31 -> 0.1.33 ``                              |
| [`df1e8683`](https://github.com/NixOS/nixpkgs/commit/df1e86833db9f4f4b0c52fb5cdabb68263b60d62) | `` home-assistant-custom-components.elegoo_printer: 2.10.2 -> 2.11.0 ``                          |
| [`70cc034b`](https://github.com/NixOS/nixpkgs/commit/70cc034bb0e7745594a5afe87ab752dca79d4733) | `` home-assistant-custom-components.ecoflow_ble: 1.0.1 -> 1.0.2 ``                               |
| [`989e7ccc`](https://github.com/NixOS/nixpkgs/commit/989e7ccc8f90dd18db8ace5698c9ac3f27e724ac) | `` python3Packages.pydantic-ai-slim: 2.13.0 -> 2.14.1 ``                                         |
| [`34d823db`](https://github.com/NixOS/nixpkgs/commit/34d823db49837e4cf39d5fa768261a3526699806) | `` python3Packages.pydantic-graph: 2.13.0 -> 2.14.1 ``                                           |
| [`96fd05e0`](https://github.com/NixOS/nixpkgs/commit/96fd05e01c63945c150024ea1d673eefa9df228f) | `` home-assistant-custom-components.daikin_onecta: 4.6.12 -> 4.6.13 ``                           |
| [`c8ed772a`](https://github.com/NixOS/nixpkgs/commit/c8ed772afc64444eff0b1fd38b9cd1d8c36de5c3) | `` vscode-extensions.ziglang.vscode-zig: 0.6.18 -> 0.6.19 ``                                     |
| [`f98476d0`](https://github.com/NixOS/nixpkgs/commit/f98476d04f2a469bc3f4cfb75bd94675946279b3) | `` ghidra-extensions.ghidra-golanganalyzerextension: 1.3.0 -> 1.4.0 ``                           |
| [`58d6fde1`](https://github.com/NixOS/nixpkgs/commit/58d6fde159bd16b3b4f3faa84c723a729ee7269a) | `` gotify-cli: 2.3.2 -> 2.4.0 ``                                                                 |
| [`c8805612`](https://github.com/NixOS/nixpkgs/commit/c8805612da53fc579dfad92fc6a3f7c1fa84a248) | `` folia-major: 0.5.27 -> 0.6.1 ``                                                               |
| [`93b7f837`](https://github.com/NixOS/nixpkgs/commit/93b7f83727ac4717966b11ef991787f156fb07d1) | `` kakoune-lsp: 21.0.1 -> 21.0.2 ``                                                              |
| [`4a45de05`](https://github.com/NixOS/nixpkgs/commit/4a45de05bdaf305a8f18cc61b114e6f3580cad46) | `` workflows: appease zizmor by installing npm pkgs from lockfile ``                             |
| [`ad53d9b5`](https://github.com/NixOS/nixpkgs/commit/ad53d9b597c17121183a07597573a27110865d9f) | `` terraform-providers.brightbox_brightbox: 3.4.3 -> 3.4.4 ``                                    |
| [`1c281358`](https://github.com/NixOS/nixpkgs/commit/1c28135859ae8769e2b1952fe661ca4429179356) | `` ci/github-script/lint-commits: add more conventional commit prefixes ``                       |
| [`f81eb0b2`](https://github.com/NixOS/nixpkgs/commit/f81eb0b260fd873750cb2e2e5523c9c2126c6a9c) | `` Revert "python3Packages.pygraphviz: unbreak on Darwin" ``                                     |
| [`e586aa8c`](https://github.com/NixOS/nixpkgs/commit/e586aa8c0b6e4400800270af1a6c83ef368f2669) | `` suitesparse-graphblas: 10.3.1 -> 10.3.2 ``                                                    |
| [`5b8dd660`](https://github.com/NixOS/nixpkgs/commit/5b8dd6608ec7ab08e3f4d1ed6ab4745262e6ded8) | `` python3Packages.glyphtools: use finalAttrs ``                                                 |
| [`2ba1187f`](https://github.com/NixOS/nixpkgs/commit/2ba1187f6499015b27190040892fcafe87d29b0c) | `` python3Packages.glytools: migrate to pyproject ``                                             |
| [`8d5f70a0`](https://github.com/NixOS/nixpkgs/commit/8d5f70a07e4dbbd0117e39d8e843b8c3696ad6fc) | `` emacs.pkgs.uniline: 20260718.1006 -> 20260721.1504 ``                                         |
| [`fa905e6a`](https://github.com/NixOS/nixpkgs/commit/fa905e6a7245802fb54f3ebe02c31293d7ad3a49) | `` codex: 0.144.4 -> 0.145.0 ``                                                                  |
| [`53e47adb`](https://github.com/NixOS/nixpkgs/commit/53e47adb64abde5805f12fc4edbb0ccff521ffc8) | `` terraform-providers.sumologic_sumologic: 3.2.9 -> 3.2.10 ``                                   |
| [`e679b239`](https://github.com/NixOS/nixpkgs/commit/e679b23917221b7162f68fca3b823f7654867008) | `` python3Packages.linode-api4: use pyprojectVersionPatchHook ``                                 |
| [`c80cdad3`](https://github.com/NixOS/nixpkgs/commit/c80cdad3f8792b64b1a6890c62a9da82d57e3bac) | `` python3Packages.scaleway: use pyprojectVersionPatchHook ``                                    |
| [`76ba128c`](https://github.com/NixOS/nixpkgs/commit/76ba128cbfadae1a763cd667a797c7b50fb20736) | `` soteria: 0.3.1 -> 0.3.2 ``                                                                    |
| [`1f9d2236`](https://github.com/NixOS/nixpkgs/commit/1f9d22369fbf755b4b37b1f4cc22080cf389b7de) | `` python3Packages.scaleway-core: use pyprojectVersionPatchHook ``                               |
| [`77aa4da5`](https://github.com/NixOS/nixpkgs/commit/77aa4da574ecc2b714ef8ad4b58ae76eb07566ef) | `` xmlrpc_c: set meta.changelog ``                                                               |
| [`0a97deac`](https://github.com/NixOS/nixpkgs/commit/0a97deac0ea04392855fad93f60026845daaebc8) | `` xmlrpc_c: enable __structuredAttrs, strictDeps ``                                             |
| [`ecd6960e`](https://github.com/NixOS/nixpkgs/commit/ecd6960e8f2bda64c216fed49d5e4ab14f2adf3a) | `` nerva: 1.42.4 -> 1.42.6 ``                                                                    |
| [`7aa20193`](https://github.com/NixOS/nixpkgs/commit/7aa20193ef7ad602223c86f3d3dfe7d05b2fce6d) | `` python3Packages.tencentcloud-sdk-python: 3.1.136 -> 3.1.138 ``                                |
| [`accdb84c`](https://github.com/NixOS/nixpkgs/commit/accdb84cfce72bb51b14365ab665950071058801) | `` python313Packages.iamdata: 0.1.202607201 -> 0.1.202607211 ``                                  |
| [`e5f92903`](https://github.com/NixOS/nixpkgs/commit/e5f929032e6ad532647ad355e737e6c751c4302e) | `` ripgrep: fix cross build Linux to FreeBSD ``                                                  |
| [`545cf26b`](https://github.com/NixOS/nixpkgs/commit/545cf26bdd9b557890a5c0bd96ad2e11e2bab180) | `` ananicy-rules-cachyos: 0-unstable-2026-07-11 -> 0-unstable-2026-07-20 ``                      |
| [`1c30f129`](https://github.com/NixOS/nixpkgs/commit/1c30f129819139aa75717a20afd744215fe869fe) | `` mtail: 3.4.3 -> 3.4.4 ``                                                                      |
| [`c194ded1`](https://github.com/NixOS/nixpkgs/commit/c194ded176c03b0ef42d45202c562ec65e4b48f4) | `` playball: 3.4.0 -> 3.5.0 ``                                                                   |
| [`029c5757`](https://github.com/NixOS/nixpkgs/commit/029c575725242fa41b589954efd3a309a17b3277) | `` clickhouse-backup: 2.7.4 -> 2.8.0 ``                                                          |
| [`179acaea`](https://github.com/NixOS/nixpkgs/commit/179acaea8e42f00db1fd7e62086e1d0fd1753d7b) | `` python3Packages.grip: use pytestCheckHook ``                                                  |
| [`989ff0b9`](https://github.com/NixOS/nixpkgs/commit/989ff0b9268e3a8eb54a9802bc1e0eb54754b66c) | `` python3Packages.guntamatic: 1.9.1 -> 1.9.2 ``                                                 |
| [`8c22e94d`](https://github.com/NixOS/nixpkgs/commit/8c22e94dcd256ed298b9cdd3f72dfafd5ca6b926) | `` perlPackages.YAMLSyck: 1.45 -> 1.47 ``                                                        |
| [`f4d41f88`](https://github.com/NixOS/nixpkgs/commit/f4d41f887545941d0ec1670d9791ec20425afcc5) | `` sc-controller: 0.5.5 -> 0.6.2 ``                                                              |
| [`d42da8a0`](https://github.com/NixOS/nixpkgs/commit/d42da8a083d004dacdaa2d4b50550d6a9e861992) | `` nixos/account-utils: support config file ``                                                   |
| [`7a00a681`](https://github.com/NixOS/nixpkgs/commit/7a00a681ee2d06984159b0628787ba5b354cfcc7) | `` xmrig-mo: 6.26.0-mo3 -> 6.26.0-mo4 ``                                                         |
| [`6bb92e17`](https://github.com/NixOS/nixpkgs/commit/6bb92e174344b4177b9dafb7e1f6fd62385653ae) | `` cudaPackages.nvbandwidth: 0.9 -> 0.10.0 ``                                                    |
| [`5a170721`](https://github.com/NixOS/nixpkgs/commit/5a170721881a7d801a3f18c23c2f0108b475e464) | `` home-assistant: 2026.7.2 -> 2026.7.3 ``                                                       |
| [`074e6fa1`](https://github.com/NixOS/nixpkgs/commit/074e6fa17ae1621f6c2092bd4adb6df454498531) | `` python3Packages.zha: 2.0.0 -> 2.0.1 ``                                                        |
| [`edfc9e47`](https://github.com/NixOS/nixpkgs/commit/edfc9e47bf4398a7b0308b74166f7d04e37b02f6) | `` python3Packages.zigpy: 2.0.0 -> 2.0.1 ``                                                      |
| [`cb47d9aa`](https://github.com/NixOS/nixpkgs/commit/cb47d9aa66ba2ba866b0da58d1ba0d68f0a7e6be) | `` python3Packages.python-roborock: 5.25.0 -> 5.31.1 ``                                          |
| [`058acbe9`](https://github.com/NixOS/nixpkgs/commit/058acbe916d1de55e184acc304f1da0c7b2b4c18) | `` python3Packages.pyoverkiz: 2.0.5 -> 2.1.0 ``                                                  |
| [`a7a173ba`](https://github.com/NixOS/nixpkgs/commit/a7a173ba82125522ac3c4ae8d8d0d54706dea80d) | `` python3Packages.guntamatic: 1.9.1 -> 1.9.2 ``                                                 |
| [`4c675f0e`](https://github.com/NixOS/nixpkgs/commit/4c675f0e2fcb98510d0264c77d8f739a72524299) | `` search-vulns: 1.2.1 -> 1.2.3 ``                                                               |
| [`403bd446`](https://github.com/NixOS/nixpkgs/commit/403bd446dfff7956797f92932e4eed3175156706) | `` python3Packages.gios: 7.1.0 -> 7.1.1 ``                                                       |
| [`1a5a4c38`](https://github.com/NixOS/nixpkgs/commit/1a5a4c38e9cd31f5e52ef2ea1eba18cdafb7577e) | `` air-formatter: 0.10.0 -> 0.11.0 ``                                                            |
| [`7a679cfb`](https://github.com/NixOS/nixpkgs/commit/7a679cfbd64ca054c091e0ec03936312e44d0b09) | `` zapret: 72.12 -> 72.13 ``                                                                     |
| [`d3798238`](https://github.com/NixOS/nixpkgs/commit/d37982385b2f8d2b1c2d1ab13c7941da6ed2b16c) | `` textext: fix GUI library (GTK3) detection ``                                                  |
| [`82885438`](https://github.com/NixOS/nixpkgs/commit/828854381747498c0f1f8ec8ed54cb8125c24149) | `` vintagestory: 1.22.4 → 1.22.5 ``                                                              |
| [`28d4379b`](https://github.com/NixOS/nixpkgs/commit/28d4379b7c942844183e2359fd6b2028b776bea6) | `` stalwart_0_16: 0.16.13 -> 0.16.14 ``                                                          |
| [`8e835a0e`](https://github.com/NixOS/nixpkgs/commit/8e835a0e13e9d3a2f5e7fd00ffdfd5c264ef24d8) | `` dtach: 0.9 -> 0.9-unstable-2025-06-20 ``                                                      |
| [`375bbfc7`](https://github.com/NixOS/nixpkgs/commit/375bbfc793343a4aca40dd739ae968ed2a645e7d) | `` opencamlib: Fix build failing on deprecated flag ``                                           |
| [`c875bf07`](https://github.com/NixOS/nixpkgs/commit/c875bf07def7104232830aa3d21b4e0da866f16a) | `` dtach: add jmbaur as maintainer ``                                                            |
| [`039af069`](https://github.com/NixOS/nixpkgs/commit/039af0697faebc5e76229d44c9f161a5694c4a1f) | `` maintainers: remove jn-sena ``                                                                |
| [`ce8d3088`](https://github.com/NixOS/nixpkgs/commit/ce8d30883848244551de123d36d14d06b26faa2b) | `` wasm-component-ld: 0.5.26 -> 0.5.27 ``                                                        |
| [`c00f8bc0`](https://github.com/NixOS/nixpkgs/commit/c00f8bc01c332ad7f5d4a6eca53d117938da93d1) | `` clickhouse: preserve VERSION_REVISION from the source tree ``                                 |
| [`7e7c6ca5`](https://github.com/NixOS/nixpkgs/commit/7e7c6ca50adb964bd57e632954fa22c16f2ddf4a) | `` yamlscript: 0.2.27 -> 0.2.29 ``                                                               |
| [`cc55273d`](https://github.com/NixOS/nixpkgs/commit/cc55273de48531798635c313aea9714560fb9fd5) | `` ninjabrain-bot: init at 1.5.2 ``                                                              |
| [`dce4c1b1`](https://github.com/NixOS/nixpkgs/commit/dce4c1b17a6911a15df70e88bcf6544f866742c0) | `` quickder: Switch to native namespace package style ``                                         |
| [`0206799d`](https://github.com/NixOS/nixpkgs/commit/0206799dbd9b1ee8312409ff154d37c7efd4e008) | `` arpa2-leaf: Switch to gitUpdater ``                                                           |
| [`0635abd1`](https://github.com/NixOS/nixpkgs/commit/0635abd1f6a0d23b02d1fb8cff0ec8253f7754c4) | `` quick-sasl: Switch to gitUpdater ``                                                           |
| [`53c5a505`](https://github.com/NixOS/nixpkgs/commit/53c5a5054d226768e0d1f7e415e77794581599b9) | `` quickder: Add updateScript ``                                                                 |
| [`910447c0`](https://github.com/NixOS/nixpkgs/commit/910447c01ecb0c92007d989f8a8879952f26d062) | `` quickmem: Add updateScript ``                                                                 |
| [`d789e730`](https://github.com/NixOS/nixpkgs/commit/d789e730788f91e3749a3eaf3db62a52a4b7ba70) | `` arpa2-leaf: 0.2 -> 0.3 ``                                                                     |
| [`656a4010`](https://github.com/NixOS/nixpkgs/commit/656a40102db68794d5b3ef77fce58fac5ab8e938) | `` quick-sasl: 0.13.2 -> 0.14.0 ``                                                               |
| [`1fcd0d95`](https://github.com/NixOS/nixpkgs/commit/1fcd0d95f46e50a15a511a45736c33970e34f69e) | `` dblab: 0.44.1 -> 0.46.0 ``                                                                    |
| [`fb268d33`](https://github.com/NixOS/nixpkgs/commit/fb268d330d7ed5b78ce419b84e00a99ce62fabf4) | `` ags: drop myself from maintainers ``                                                          |
| [`26fcc194`](https://github.com/NixOS/nixpkgs/commit/26fcc19435cd352a2c2aadef4f204b64e7c158e8) | `` astal: drop myself from maintainers ``                                                        |
| [`aa12d137`](https://github.com/NixOS/nixpkgs/commit/aa12d137480c9149c0207658b66485a842985979) | `` antigravity-ide: 2.0.3 -> 2.1.1 ``                                                            |
| [`3f645260`](https://github.com/NixOS/nixpkgs/commit/3f64526064e5fa3ada6189aaf6f4a0b5ab6ded7f) | `` dropbear: 2026.92 -> 2026.93 ``                                                               |
| [`98ac34f0`](https://github.com/NixOS/nixpkgs/commit/98ac34f02e5cd61b6c9490f430ff33e2269f9ddf) | `` doppler: 3.76.0 -> 3.76.1 ``                                                                  |
| [`3ea94c84`](https://github.com/NixOS/nixpkgs/commit/3ea94c84131dcef1964201303f154a361e798ea2) | `` skills: 1.5.16 -> 1.5.19 ``                                                                   |
| [`9e379409`](https://github.com/NixOS/nixpkgs/commit/9e37940901066ce65b23e2973a7be2c2f16cd8ba) | `` antigravity: rename to antigravity-ide ``                                                     |
| [`ef919c1a`](https://github.com/NixOS/nixpkgs/commit/ef919c1a8bb0d1b6a9aa8c8afede8b97082abd69) | `` vscode: add strictDeps and structuredAttrs ``                                                 |
| [`5510b23d`](https://github.com/NixOS/nixpkgs/commit/5510b23d77835ab68f88d500b9f9fa4f4d9adfcc) | `` hyprpanel: drop ``                                                                            |
| [`07173bfb`](https://github.com/NixOS/nixpkgs/commit/07173bfbadc24b5013f08914274631bda74ae079) | `` git-pkgs: 0.17.0 -> 0.18.0 ``                                                                 |
| [`62250c7b`](https://github.com/NixOS/nixpkgs/commit/62250c7bc16b4015f577cb251167bfabbb713a0c) | `` fzf-make: 0.69.0 -> 0.70.0 ``                                                                 |
| [`693a17c7`](https://github.com/NixOS/nixpkgs/commit/693a17c70b430fad75ad1b1d1dadf5769c4b516a) | `` gvm-libs: 23.8.0 -> 23.9.0 ``                                                                 |
| [`2c0fe952`](https://github.com/NixOS/nixpkgs/commit/2c0fe95227686c5501758f549a5599904d510204) | `` fosrl-pangolin: 1.19.4 -> 1.21.0 ``                                                           |
| [`85f35c0a`](https://github.com/NixOS/nixpkgs/commit/85f35c0af6ae86b9e6adbf1156915244adad46d8) | `` postman: remove myself as maintainer ``                                                       |
| [`d9ba3283`](https://github.com/NixOS/nixpkgs/commit/d9ba3283847e25c51ba3d6e5eef99f50c6b482fd) | `` vscode-extensions.anthropic.claude-code: 2.1.215 -> 2.1.216 ``                                |
| [`ca1770fd`](https://github.com/NixOS/nixpkgs/commit/ca1770fd70dfb5b9997a03d13238876dd3e28ab1) | `` claude-code: 2.1.215 -> 2.1.216 ``                                                            |
| [`4ca84bd6`](https://github.com/NixOS/nixpkgs/commit/4ca84bd6ffa9c7f8d2aeca587a112c0bed7f9ec0) | `` lima-full: 2.1.4 -> 2.2.0 ``                                                                  |
| [`b74cf98d`](https://github.com/NixOS/nixpkgs/commit/b74cf98da8e7493482a36e472e39434f2c3199a9) | `` gnomeExtensions.user-themes-x: add patch for libglycin{,-gtk4} ``                             |
| [`84224d7c`](https://github.com/NixOS/nixpkgs/commit/84224d7c2c7578cf874fe1d81110e27f719f990f) | `` nixosTests/gnome-extensions: fix checkExtension conditional ``                                |
| [`4e626fe7`](https://github.com/NixOS/nixpkgs/commit/4e626fe7e5fb12915839917385a631df2dce22ef) | `` gnomeExtensions: drop unmaintained extensions ``                                              |
| [`6a1273d6`](https://github.com/NixOS/nixpkgs/commit/6a1273d665a1e94eb0e3fbdc87fd5b2895327375) | `` ziglint: init at 0.5.3 ``                                                                     |
| [`042f5c05`](https://github.com/NixOS/nixpkgs/commit/042f5c0583a87d89462e651b19028c2a652b2d2d) | `` maintainers: add xqtc161 ``                                                                   |
| [`8c14d67c`](https://github.com/NixOS/nixpkgs/commit/8c14d67c7c02a74b1d51837385d7ae723f3244e8) | `` obs-cmd: 1.0.0 -> 1.0.1 ``                                                                    |
| [`a417c747`](https://github.com/NixOS/nixpkgs/commit/a417c7478897e8d7bdc6b9483d91796ca3124588) | `` afew: 4.0.1 -> 4.0.2 ``                                                                       |
| [`e2e472b1`](https://github.com/NixOS/nixpkgs/commit/e2e472b182309479b69882ca51c59b7f469b6f62) | `` python3Packages.py-ecc: fix changelog ``                                                      |
| [`7a3c41fe`](https://github.com/NixOS/nixpkgs/commit/7a3c41fed321690682c213e99447478312f423e1) | `` python3Packages.py-cpuinfo: fix changelog ``                                                  |
| [`6c4e3498`](https://github.com/NixOS/nixpkgs/commit/6c4e3498c9c14e684f18d2cea65a2ef9e56a36cc) | `` python3Packages.precis-i18n: fix changelog ``                                                 |
| [`3586fe53`](https://github.com/NixOS/nixpkgs/commit/3586fe53d546394bf2c69d99cf8006788c7897c1) | `` python3Packages.pluginbase: remove changelog ``                                               |
| [`d310323e`](https://github.com/NixOS/nixpkgs/commit/d310323eed56dca6dfcd24f9a6507d7f0453cc72) | `` python3Packages.pg8000: update homepage and changelog ``                                      |
| [`534a8f3e`](https://github.com/NixOS/nixpkgs/commit/534a8f3eb96b436e7534371a624bb6d8e13e7137) | `` python3Packages.panflute: comment out changelog ``                                            |
| [`9b584cf2`](https://github.com/NixOS/nixpkgs/commit/9b584cf2aae64bba5413077796b5a23a181a2a4c) | `` python3Packages.limnoria: remove changelog ``                                                 |
| [`13ef7cb4`](https://github.com/NixOS/nixpkgs/commit/13ef7cb44addff454e3ce80fd48cce6c7222dafb) | `` python3Packages.lazr-restfulclient: update homepage, remove changelog ``                      |
| [`8ce4c122`](https://github.com/NixOS/nixpkgs/commit/8ce4c122d4993196f748b079fa08654ed53cae2d) | `` python3Packages.hdbscan: fix changelog ``                                                     |
| [`91b3c26d`](https://github.com/NixOS/nixpkgs/commit/91b3c26dcdd6d091e2996fd501194ccf13b103f5) | `` python3Packages.hatch-requirements-txt: remove changelog ``                                   |
| [`431edb77`](https://github.com/NixOS/nixpkgs/commit/431edb77dbb24ee5c5844b2df8c75ab14f89e612) | `` python3Packages.hatch-babel: comment out changelog ``                                         |
| [`cff193a5`](https://github.com/NixOS/nixpkgs/commit/cff193a5c941079964b05b6f246875edb65f5e04) | `` python3Packages.google-cloud-dns: update homepage and changelog ``                            |
| [`1bc8e0b3`](https://github.com/NixOS/nixpkgs/commit/1bc8e0b3aee57fa41b5bb2f2b0226f8263662925) | `` python3Packages.google-cloud-datastore: update homepage and changelog ``                      |
| [`057033a1`](https://github.com/NixOS/nixpkgs/commit/057033a1f08fbcbf10ffdae40c0cdab8c3161a43) | `` python3Packages.google-cloud-bigquery-storage: update homepage and changelog ``               |
| [`d953dc0d`](https://github.com/NixOS/nixpkgs/commit/d953dc0dbbb6971b1c0fd4861bef47988ec15d2f) | `` python3Packages.flask-mongoengine: fix changelog ``                                           |
| [`fd8afb4a`](https://github.com/NixOS/nixpkgs/commit/fd8afb4abc34806a582c1c25fa7697c362b3f848) | `` python3Packages.flask-login: fix changelog ``                                                 |
| [`b542dca3`](https://github.com/NixOS/nixpkgs/commit/b542dca392eb320c698bea8f478eeee5740284fc) | `` python3Packages.feedparser: fix changelog ``                                                  |
| [`57bee9f8`](https://github.com/NixOS/nixpkgs/commit/57bee9f89540c52b1400ab4e77d43344137b0b65) | `` python3Packages.favicon: fix changelog ``                                                     |
| [`c93573a1`](https://github.com/NixOS/nixpkgs/commit/c93573a16486b932c63355e74ab3b8f9ac2d7e3c) | `` python3Packages.dbt-redshift: fix changelog ``                                                |
| [`1ed61023`](https://github.com/NixOS/nixpkgs/commit/1ed61023f55f06ee34003164d3a7f97fcab2a5a9) | `` python3Packages.dbt-bigquery: fix changelog link ``                                           |
| [`3b0aa6ae`](https://github.com/NixOS/nixpkgs/commit/3b0aa6ae504a23ecf40069b3cfb9a3c92956ca2f) | `` python3Packages.cssselect: fix changelog url format ``                                        |
| [`16f3fc46`](https://github.com/NixOS/nixpkgs/commit/16f3fc4680e86b35e11a859a9a344a7e6ccb3dc5) | `` python3Packages.compreffor: fix changelog ``                                                  |
| [`1ddc344f`](https://github.com/NixOS/nixpkgs/commit/1ddc344ffa23209e889d6e1c551074706fd01dae) | `` pop: add versionCheckHook and explicit updateScript ``                                        |
| [`935f1ec3`](https://github.com/NixOS/nixpkgs/commit/935f1ec3e3698f9602f3be5032728545c3c1bc94) | `` emacsPackages.ghostel: 0.41.0-unstable-2026-07-06 -> 0.44.0 ``                                |
| [`adc68602`](https://github.com/NixOS/nixpkgs/commit/adc68602b7f592894052962bd52d237d66118716) | `` rmtfs: 1.1.1 -> 1.3 ``                                                                        |
| [`7ba5d098`](https://github.com/NixOS/nixpkgs/commit/7ba5d098ea4c8ba6fe5875e54bfb35308b124c16) | `` at: substituteInPlace replace with replace-fail ``                                            |
| [`7a0bb42e`](https://github.com/NixOS/nixpkgs/commit/7a0bb42e1b34354ba4c4202f1c2f6989e66bdc1e) | `` sshocker: 0.3.9 -> 0.3.11 ``                                                                  |
| [`fdc36250`](https://github.com/NixOS/nixpkgs/commit/fdc3625055b54b969124aba296a66a6d3ef97883) | `` libbde: fuse -> fuse3 ``                                                                      |
| [`43537c77`](https://github.com/NixOS/nixpkgs/commit/43537c774af2c7dc9d616a9159738107cbb015d9) | `` nixtamal: 1.9.1 → 1.9.2 ``                                                                    |
| [`8238cfe2`](https://github.com/NixOS/nixpkgs/commit/8238cfe212218fad350c8761491fac9dd67ef95c) | `` stevenblack-blocklist: 3.16.97 -> 3.16.99 ``                                                  |
| [`34b20850`](https://github.com/NixOS/nixpkgs/commit/34b208501bcbfbe6f39407b8034417c33c9854ce) | `` nerva: 1.40.2 -> 1.42.4 ``                                                                    |
| [`495df12c`](https://github.com/NixOS/nixpkgs/commit/495df12c7382327d7cb688f6188ca97a9936a3ca) | `` gphoto2fs: 0.5.0 -> 1.0; modernize ``                                                         |
| [`3154ec45`](https://github.com/NixOS/nixpkgs/commit/3154ec4542736a6e17178a43dc50d587b01848df) | `` ci/pinned: bump nixpkgs ``                                                                    |
| [`64e9fc19`](https://github.com/NixOS/nixpkgs/commit/64e9fc196be26deaf0d940eb2799a3ee50adb215) | `` git-statuses: 0.8.1 -> 0.8.2 ``                                                               |
| [`65291263`](https://github.com/NixOS/nixpkgs/commit/652912633910050ccc5f9b2e7bf3986438df8b72) | `` luarocks-packages-updater: format updater ``                                                  |
| [`c60bed67`](https://github.com/NixOS/nixpkgs/commit/c60bed67decc488dfbbde97cb4e858a83137fdbc) | `` gitea-actions-runner: 1.0.3 -> 2.1.0 ``                                                       |
| [`65cbf79c`](https://github.com/NixOS/nixpkgs/commit/65cbf79c56c240ac5865cceb26827d2f18525794) | `` gitea-actions-runner: add update script ``                                                    |
| [`3ba52b0d`](https://github.com/NixOS/nixpkgs/commit/3ba52b0d7ac66e1ed0bd7e94a5ce06ef04258da2) | `` luarocks-packages-updater: support initial maintainer ``                                      |
| [`92b39ca4`](https://github.com/NixOS/nixpkgs/commit/92b39ca453117d5292b5980ca93915a93f6b74c2) | `` luaPackages.canola-nvim: add saadndm as maintainer ``                                         |
| [`05459850`](https://github.com/NixOS/nixpkgs/commit/05459850b85eba7ea3fe82a977b5b408fb9d5493) | `` python3Packages.insightface: cleanup ``                                                       |
| [`7cd3db89`](https://github.com/NixOS/nixpkgs/commit/7cd3db892112650606e1bd264a78222ce139b86b) | `` python3Packages.albumentationx: init at 2.3.3 ``                                              |
| [`21641d65`](https://github.com/NixOS/nixpkgs/commit/21641d653f90f20cbc6eb499ff4fa331e3e3829e) | `` python3Packages.albumentations: drop ``                                                       |
| [`098b0771`](https://github.com/NixOS/nixpkgs/commit/098b0771f3e9114befac97139d10e550c8e26af1) | `` python3Packages.albucore: 0.0.24 -> 0.2.4 ``                                                  |
| [`aae789a1`](https://github.com/NixOS/nixpkgs/commit/aae789a125dc036ac6fff61690203afbba825e86) | `` centrifugo: 6.6.2 -> 6.9.1 ``                                                                 |
| [`557ffb2f`](https://github.com/NixOS/nixpkgs/commit/557ffb2ffaa12f5ac1ea77266db875970b84570a) | `` nixos/treewide: use security.pam.pam_unixModulePath ``                                        |
| [`7c580bac`](https://github.com/NixOS/nixpkgs/commit/7c580bacc65b1a88c358a98652feb94568c7a41f) | `` mumps: 5.9.0 -> 5.9.1 ``                                                                      |
| [`75cb06aa`](https://github.com/NixOS/nixpkgs/commit/75cb06aa2691676ec322afecd02879b2e4441451) | `` account-utils: enable checks ``                                                               |
| [`40837a08`](https://github.com/NixOS/nixpkgs/commit/40837a0827e4b03636676e84351e09a61ebf7eac) | `` account-utils: 1.3.0 -> 1.4.0 ``                                                              |
| [`b1a94aa0`](https://github.com/NixOS/nixpkgs/commit/b1a94aa05add38276f31377079abdf8b8dc6fcb3) | `` emacs.pkgs.shexc-ts-mode: fix build ``                                                        |
| [`61e749fa`](https://github.com/NixOS/nixpkgs/commit/61e749fafeb11419db3e65b39ed9b58e94b63986) | `` zwave-js-ui: 11.21.1 -> 11.22.0 ``                                                            |
| [`80d94bb3`](https://github.com/NixOS/nixpkgs/commit/80d94bb38e522fef5aeab7d4531f917edbc8d220) | `` gst-plugins-rs: 0.14.4 -> 0.15.3 ``                                                           |
| [`e67582ba`](https://github.com/NixOS/nixpkgs/commit/e67582ba93c2e2d4d8b9616f68ebfa6f8a63e992) | `` samrewritten: 1.4.4 -> 1.4.5 ``                                                               |
| [`c6fffb6e`](https://github.com/NixOS/nixpkgs/commit/c6fffb6e8fa3c05a63251a09153e46e10d2689d3) | `` mullvad-browser: 15.0.18 -> 15.0.19 ``                                                        |
| [`6b1b2542`](https://github.com/NixOS/nixpkgs/commit/6b1b254228d0c396307a10838f0af543354ecd3e) | `` tor-browser: 15.0.18 -> 15.0.19 ``                                                            |
| [`757a80d9`](https://github.com/NixOS/nixpkgs/commit/757a80d9c83cd2eabcde1af7aaaf1feb6579e41a) | `` emacs.pkgs.lisp-ts-mode: 0.2.1 -> 0.3.0 ``                                                    |
| [`fb4c9851`](https://github.com/NixOS/nixpkgs/commit/fb4c98518c2db17ea0898ee2ab20cff9cfee73bb) | `` forgejo: 16.0.0 -> 16.0.1 ``                                                                  |
| [`4d721828`](https://github.com/NixOS/nixpkgs/commit/4d7218282f070184b0c4284b205deddfdff3973f) | `` melonds: 1.1-unstable-2026-06-07 -> 1.1-unstable-2026-07-19 ``                                |
| [`be9a23a3`](https://github.com/NixOS/nixpkgs/commit/be9a23a3b2db45bc04d457505b1a1a8615f1fc1c) | `` llama-swap-minimal: init ``                                                                   |
| [`39c4d8f8`](https://github.com/NixOS/nixpkgs/commit/39c4d8f88949562f9426cefb1be2f21d1e7a366f) | `` llama-swap: optionalize ui ``                                                                 |
| [`6b9619fd`](https://github.com/NixOS/nixpkgs/commit/6b9619fd67f7f80494b67dd5ed743dbff5df81c0) | `` llama-swap: 224 -> 240 ``                                                                     |
| [`a09353ae`](https://github.com/NixOS/nixpkgs/commit/a09353aeca6f1dbb1b5cf386bcdcb1c99b65fef0) | `` llama-swap: remove unnecessary parentheses ``                                                 |
| [`6b6b1f67`](https://github.com/NixOS/nixpkgs/commit/6b6b1f67e508ac7ad49f49cfc945bd261b9ccf1d) | `` llama-swap: use replace-fail ``                                                               |
| [`2ef1bb2b`](https://github.com/NixOS/nixpkgs/commit/2ef1bb2b3e6b4b3e2b4adc7976ca42b86967ff46) | `` nixos/llama-swap: option to share model cache with nixos/llama-cpp module ``                  |
| [`b4c2c6d6`](https://github.com/NixOS/nixpkgs/commit/b4c2c6d69db80418377dc3dae7aa1ea44d919a4b) | `` python3Packages.pyoverkiz: 2.0.5 -> 2.1.0 ``                                                  |
| [`a87d1cf5`](https://github.com/NixOS/nixpkgs/commit/a87d1cf5f8b82232923784b4da818bca2c30064f) | `` dump_syms: 2.3.7 -> 2.3.8 ``                                                                  |
| [`583489bc`](https://github.com/NixOS/nixpkgs/commit/583489bcd091f404223b4b5e45289d4f44926c92) | `` mcp-gateway: 3.3.0 -> 3.3.2 ``                                                                |
| [`a7e4216a`](https://github.com/NixOS/nixpkgs/commit/a7e4216a6cb306cbcf10fc7cc8905947d602a206) | `` tombi: 1.2.2 -> 1.2.4 ``                                                                      |
| [`ae3ee288`](https://github.com/NixOS/nixpkgs/commit/ae3ee2881e390709db33b12d2a7d62c9d9cbafe3) | `` gnomeExtensions.unite: 84 -> 85 ``                                                            |
| [`378aa2ae`](https://github.com/NixOS/nixpkgs/commit/378aa2aeaa8dbfee7be15de8815238c0294de583) | `` gnomeExtensions.impatience: 0.5.3-unstable-2025-10-06 -> 0.5.3-unstable-2026-03-11 ``         |
| [`31a9a166`](https://github.com/NixOS/nixpkgs/commit/31a9a1665910251caca9a9873ecd4504d5b21de7) | `` gnomeExtensions.guillotine: 26 -> 27-unstable-2026-04-08 ``                                   |
| [`f8e9d6cf`](https://github.com/NixOS/nixpkgs/commit/f8e9d6cf64ea732d6fa4588e21cb9cb808c61f08) | `` gnomeExtensions.argos: unstable-2025-09-25 -> 50 ``                                           |

*... and 1690 more commits (truncated)*