### PR TITLE
chore(flake/precommit): `a994d570` -> `42c10474`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -206,11 +206,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1786105217,
-        "narHash": "sha256-ySp0dc1E9ZorICTvG1467QKzZYCp0fcBECEeycz3Dtw=",
+        "lastModified": 1786691678,
+        "narHash": "sha256-As8gQAwfN9UFfI0w62bPz60PF2GBa6QYL+MoP7PhWro=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "a994d570247f1d80cbbcd8a33c4b4f866e16af87",
+        "rev": "42c10474772f46184668827c86ed97fc7fbd3fb3",
         "type": "github"
       },
       "original": {
@@ -273,11 +273,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1786076960,
-        "narHash": "sha256-jfR6OhwurCKn1tREyfOcK/Omxf1Q/DzDDFbnEr1mBLs=",
+        "lastModified": 1786680812,
+        "narHash": "sha256-5lDFwethgqSULdupYl3Eu5n80jfcbb85gSJX/jb58GQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "57a23bfaf4f7017267294b161175db1e32eb1c85",
+        "rev": "f1dcc7e4ea4fdb6d8f276face22f353832b161e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`42c10474`](https://github.com/fredsystems/pre-commit-checks/commit/42c10474772f46184668827c86ed97fc7fbd3fb3) | `` chore(flake/rust-overlay): 892c035d -> f1dcc7e4 `` |
| [`edd622fd`](https://github.com/fredsystems/pre-commit-checks/commit/edd622fddbac6968ee7185e28abb3a7b9bc289f1) | `` update flake inputs ``                             |