### PR TITLE
chore(flake/nixpkgs): `f13ff45a` -> `0e251e24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -115,11 +115,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                  |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`b9b6512c`](https://github.com/NixOS/nixpkgs/commit/b9b6512c2d6542426bc2adab276d0766db8c7998) | `` mongodb-atlas-cli: 1.57.0 -> 1.58.0 ``                                                                |
| [`1932e3cb`](https://github.com/NixOS/nixpkgs/commit/1932e3cb3b79adef685033ef2321109536b8586c) | `` freetube: 0.25.1 -> 0.25.2; pin electron version ``                                                   |
| [`7b8031d7`](https://github.com/NixOS/nixpkgs/commit/7b8031d7b7585f049682a26afe63f5bb7d1df256) | `` python3Packages.stringzilla: 5.0.7 -> 5.1.2 ``                                                        |
| [`d40b16d6`](https://github.com/NixOS/nixpkgs/commit/d40b16d624bf9ea44b405187e34a543e86e15495) | `` nixos/compsize: init ``                                                                               |
| [`827e1f12`](https://github.com/NixOS/nixpkgs/commit/827e1f127755216e80978ace268786adfab118e0) | `` wdt: pin to c++20 for folly headers ``                                                                |
| [`81b5d5c3`](https://github.com/NixOS/nixpkgs/commit/81b5d5c3361c5268e9e3eb70d7371860e1d3bc8d) | `` watchman: 2026.01.19.00 -> 2026.07.27.00 ``                                                           |
| [`377c1c1e`](https://github.com/NixOS/nixpkgs/commit/377c1c1e33b87d1c51585325fe1d02f105a45922) | `` nixos/btrfs-heatmap: init ``                                                                          |
| [`00632b3d`](https://github.com/NixOS/nixpkgs/commit/00632b3dd142eaf9126d48b6fe171a1b1de67d03) | `` evcc: 0.313.2 -> 0.313.3 ``                                                                           |
| [`9f61d8b1`](https://github.com/NixOS/nixpkgs/commit/9f61d8b1422067af82d5412e6918cc1b8e3e12e2) | `` fromager: 0.91.0 -> 0.94.0 ``                                                                         |
| [`678dd7b1`](https://github.com/NixOS/nixpkgs/commit/678dd7b1494662da9172772c07ff1acf63523877) | `` edencommon: 2026.01.19.00 -> 2026.07.27.00 ``                                                         |
| [`33589cc0`](https://github.com/NixOS/nixpkgs/commit/33589cc0c6fd4e0325bb5310fffd2ecf707db2fa) | `` lib/systems: derive more platform metadata instead of restating it ``                                 |
| [`ef34f35e`](https://github.com/NixOS/nixpkgs/commit/ef34f35e454a9c035b7edbeebea23f529f86e296) | `` lib.fileset: start by recursing into the initial element ``                                           |
| [`f03b66c6`](https://github.com/NixOS/nixpkgs/commit/f03b66c61ad0801cf6ac55241b2ab1e9bc90afc8) | `` shadps4{,-qtlauncher}: modernize ``                                                                   |
| [`ed031862`](https://github.com/NixOS/nixpkgs/commit/ed0318621d83b0b5a5d43dc74bb1c32d90e33688) | `` shadps4-qtlauncher: 0-unstable-2026-06-07 -> 0-unstable-2026-08-08 ``                                 |
| [`3d43da3d`](https://github.com/NixOS/nixpkgs/commit/3d43da3db6ce0e201e886765b3d52dfae5c0d608) | `` shadps4: 0.16.0 -> 0.17.0 ``                                                                          |
| [`fe37e78d`](https://github.com/NixOS/nixpkgs/commit/fe37e78deb736e262852a52c007a7c5b68b82064) | `` home-assistant-custom-components.local_openai: 1.9.0 -> 1.10.0 ``                                     |
| [`2ef1b376`](https://github.com/NixOS/nixpkgs/commit/2ef1b3763c962665844d8e695971cfc2f05dc7da) | `` python314Packages.docling-slim: use pytest-xdist to half test time ``                                 |
| [`610d9619`](https://github.com/NixOS/nixpkgs/commit/610d96198070e201f93e4833a35c477463bb5f80) | `` python3Packages.py-dactyl: 2.1.2 -> 2.1.3 ``                                                          |
| [`20cf7fb8`](https://github.com/NixOS/nixpkgs/commit/20cf7fb86b159be42e4c0d6141afb8dd6688a3dd) | `` terraform-providers.fastly_fastly: 9.4.0 -> 9.6.0 ``                                                  |
| [`89a98a8f`](https://github.com/NixOS/nixpkgs/commit/89a98a8f7a81aba98ab96ce5e809504ba6d7a1ad) | `` hunk: inline use of pname ``                                                                          |
| [`b5c45516`](https://github.com/NixOS/nixpkgs/commit/b5c455162761ac7b06bf7aace39b7b888f58402f) | `` radicle-node-unstable: 1.10.0 -> 1.10.1 ``                                                            |
| [`aa97414e`](https://github.com/NixOS/nixpkgs/commit/aa97414e9811e786789decf01930ad55395b61ea) | `` radicle-node: 1.10.0 -> 1.10.1 ``                                                                     |
| [`763fd676`](https://github.com/NixOS/nixpkgs/commit/763fd676169cf77cfd25008cc7116375fbfcc961) | `` nix-direnv: use tag instead of rev ``                                                                 |
| [`d9de1459`](https://github.com/NixOS/nixpkgs/commit/d9de145969d5888271125053ab3a6066f1af9616) | `` wl-freeze: 2.0.2 -> 2.1.0 ``                                                                          |
| [`d5c41034`](https://github.com/NixOS/nixpkgs/commit/d5c41034b14db2ea05113103cf563fd25d6c25c1) | `` tree-sitter: support scoped grammar aliases ``                                                        |
| [`a089de30`](https://github.com/NixOS/nixpkgs/commit/a089de30fa56821ae42163f01e6f46b10ba7724b) | `` gcc/ng: describe the bootstrap chain in the README ``                                                 |
| [`85edf2c6`](https://github.com/NixOS/nixpkgs/commit/85edf2c64fc7280d594cc92981d5f23a9e8c2990) | `` gcc/ng: let libstdc++ pick its own locale model ``                                                    |
| [`fcde6eb3`](https://github.com/NixOS/nixpkgs/commit/fcde6eb30df0a8233060b89ba4c683e31169dd75) | `` gcc/ng: build libstdc++ with the C driver, and ship `libtool-ldflags` ``                              |
| [`a1a1eb02`](https://github.com/NixOS/nixpkgs/commit/a1a1eb029ba0963d006caea3e42541b5ee72b1ac) | `` gcc/ng: put libstdc++'s library and headers where each belongs ``                                     |
| [`f39d68cb`](https://github.com/NixOS/nixpkgs/commit/f39d68cbf9b40e5355af59e14928250d3110bfef) | `` gcc/ng: put the target libc's headers where they belong ``                                            |
| [`83cb4875`](https://github.com/NixOS/nixpkgs/commit/83cb487509c83ff6427d2ac738bb1ef37584f474) | `` gcc/ng: build `libgcc` twice, once for the libc and once against it ``                                |
| [`3f8e1ff9`](https://github.com/NixOS/nixpkgs/commit/3f8e1ff98b9089b1197bf5e53f78ea46a86d7822) | `` gcc/ng: add `gccWithLibgcc`, the compiler for the libc bootstrap step ``                              |
| [`be820563`](https://github.com/NixOS/nixpkgs/commit/be82056397df8e2e4ba1ed2caa09237ca3fa94c5) | `` gcc/ng: cope with a source tree that is a VCS checkout ``                                             |
| [`ab281c3f`](https://github.com/NixOS/nixpkgs/commit/ab281c3fd468477ae06a2ed9975f724635d6f4ed) | `` gcc/ng: let GCC probe the real tools, and bake neither answers nor paths ``                           |
| [`92144940`](https://github.com/NixOS/nixpkgs/commit/92144940a3acaddbb3af8694e1fc576cb6a24491) | `` gcc/ng: let a platform opt in with `useGccNG` ``                                                      |
| [`d8ad24b1`](https://github.com/NixOS/nixpkgs/commit/d8ad24b1cd45120d49e2e5b2fe900efb7fc06840) | `` gcc/ng: point libgcc's `gcc/configure` at the real target `as` and `ld` ``                            |
| [`ff6e0f6e`](https://github.com/NixOS/nixpkgs/commit/ff6e0f6e94ae9d82289bea581bf70bdd41f35685) | `` radicle-ci-broker: 0.30.0 -> 0.31.0 ``                                                                |
| [`01e64940`](https://github.com/NixOS/nixpkgs/commit/01e64940120c9c573061848b2ba1710ba8d79453) | `` terraform-providers.dnsimple_dnsimple: 2.1.2 -> 2.2.0 ``                                              |
| [`1e7ede31`](https://github.com/NixOS/nixpkgs/commit/1e7ede313f504bbce3d3ddcdcbda924ca7925121) | `` utils.mkStateRevisionOption: replace table with ol ``                                                 |
| [`7532d3bf`](https://github.com/NixOS/nixpkgs/commit/7532d3bfc24b4b89cee18cb2ef9feaba9e751cab) | `` Reapply "nixos/seerr: use lib.mkStateRevisionOption" ``                                               |
| [`eadb67ba`](https://github.com/NixOS/nixpkgs/commit/eadb67ba0ef2b4b629cb5ee2eeef4bad75a021d1) | `` rhash: add GraysonTinker as maintainer ``                                                             |
| [`9c2bb5ac`](https://github.com/NixOS/nixpkgs/commit/9c2bb5ac1738c8c53bf9989f32e332d3eac2d3e7) | `` lazygit: 0.64.0 -> 0.64.1 ``                                                                          |
| [`c82d6c12`](https://github.com/NixOS/nixpkgs/commit/c82d6c12d815f6e4cb756abb90ac2f9938085cb5) | `` prometheus-snowflake-exporter: init at 0-unstable-2026-07-02 ``                                       |
| [`822a632f`](https://github.com/NixOS/nixpkgs/commit/822a632fed49695c4ae6c73edb1e9af3f0716a3c) | `` luwen: 0.8.5 -> 0.9.0 ``                                                                              |
| [`986b139b`](https://github.com/NixOS/nixpkgs/commit/986b139bd57afad67a30b6c367eea88b439821c6) | `` megabasterd: 8.57 -> 8.58 ``                                                                          |
| [`2876516e`](https://github.com/NixOS/nixpkgs/commit/2876516ec580186c191ce8c01c2142730f5c3dbf) | `` nats-server: 2.14.4 -> 2.14.5 ``                                                                      |
| [`4bb4cff3`](https://github.com/NixOS/nixpkgs/commit/4bb4cff36852dda1e32fc2ee0d377b516ca02339) | `` stdenv: deprecate `is*` aliases in favor of `hostPlatform.is*` ``                                     |
| [`9921d05d`](https://github.com/NixOS/nixpkgs/commit/9921d05da3230adac66aa507db544c5e4e08386e) | `` treewide: replace stdenv.is* with stdenv.hostPlatform.is* ``                                          |
| [`c4b48b98`](https://github.com/NixOS/nixpkgs/commit/c4b48b9886bab8da06ecdb1102c0a70976920fa9) | `` fb303: 2026.01.19.00 -> 2026.07.27.00 ``                                                              |
| [`38a9bc17`](https://github.com/NixOS/nixpkgs/commit/38a9bc17a93c804c13d7650ed7f7ba3ebf19a3c8) | `` fbthrift: 2026.01.19.00 -> 2026.07.27.00 ``                                                           |
| [`836e0f22`](https://github.com/NixOS/nixpkgs/commit/836e0f22135b0f57f47561d66e6c2473e4e08712) | `` wangle: 2026.01.19.00 -> 2026.07.27.00 ``                                                             |
| [`e8ca289a`](https://github.com/NixOS/nixpkgs/commit/e8ca289a6cdbc3dd113016354f690803f56b866c) | `` mvfst: 2026.01.19.00 -> 2026.07.27.00 ``                                                              |
| [`26c4f676`](https://github.com/NixOS/nixpkgs/commit/26c4f676795ce0ade74e3d977953922ebbdcb5be) | `` fizz: 2026.01.19.00 -> 2026.07.27.00 ``                                                               |
| [`24b1bb1c`](https://github.com/NixOS/nixpkgs/commit/24b1bb1c187289a7dc0d777cfef9d2fcdacf7120) | `` folly: 2026.01.19.00 -> 2026.07.27.00 ``                                                              |
| [`2ab67331`](https://github.com/NixOS/nixpkgs/commit/2ab673318b42938ffd93a475ba814dde3b17c474) | `` lasuite-meet: 1.25.2 -> 1.26.0 ``                                                                     |
| [`3b58c271`](https://github.com/NixOS/nixpkgs/commit/3b58c2719e4228f15d084ef7cd83fe25f18d872d) | `` lib.fileset: compare to baseString directly ``                                                        |
| [`75bb5e65`](https://github.com/NixOS/nixpkgs/commit/75bb5e65ba8bcb1b1180da86bc437cefc160db5f) | `` zennotes-desktop: 2.25.0 -> 2.27.0 ``                                                                 |
| [`db64793d`](https://github.com/NixOS/nixpkgs/commit/db64793d70af79d8ea0c3218cba1df55ff7a4597) | `` jetbrains-toolbox: 3.6.3.86383 -> 3.6.4.86641 ``                                                      |
| [`9213fcbd`](https://github.com/NixOS/nixpkgs/commit/9213fcbd180c534a47bb0506285f9ca96a281837) | `` lib.fileset: inline let variable only used once ``                                                    |
| [`af732abb`](https://github.com/NixOS/nixpkgs/commit/af732abb9b2ac73f22a4e7d1b0c29361506aa003) | `` lib.fileset: partially apply substring logic ``                                                       |
| [`b65b89f2`](https://github.com/NixOS/nixpkgs/commit/b65b89f2decb80a031459be973823d5b567a1022) | `` lib.fileset: move let definition higher up ``                                                         |
| [`f9426d6d`](https://github.com/NixOS/nixpkgs/commit/f9426d6d330d7a4a99a4ddf7de3ef63a15866e83) | `` python3Packages.elevenlabs: 2.60.0 -> 2.63.0 ``                                                       |
| [`8c3b4eba`](https://github.com/NixOS/nixpkgs/commit/8c3b4eba3ae9cef389ab48745f0e1aa5281d43c8) | `` opencloud.web: 7.2.0 -> 7.3.0 ``                                                                      |
| [`2570777e`](https://github.com/NixOS/nixpkgs/commit/2570777ee3ce69d2eff04d0a6a1750845d35b703) | `` opencloud: 7.3.0 -> 7.4.0 ``                                                                          |
| [`7e665608`](https://github.com/NixOS/nixpkgs/commit/7e6656088126b27fee5fe08b7a9b6ae6dc4096cf) | `` python3Packages.pillow-jxl-plugin: fix license ``                                                     |
| [`4096bfa3`](https://github.com/NixOS/nixpkgs/commit/4096bfa31ca4fecf4ac24a16c7374fbed2db0e77) | `` biome: 2.5.6 -> 2.5.8 ``                                                                              |
| [`fb62ced9`](https://github.com/NixOS/nixpkgs/commit/fb62ced92e2e1ea9a1f90e7a4275f725db021ab7) | `` rime-moegirl: 20260713 -> 20260812 ``                                                                 |
| [`aa3d058b`](https://github.com/NixOS/nixpkgs/commit/aa3d058bd15ae4180db22a1973e6ed3e0e7eb07e) | `` python3Packages.warp-nn: 0.3.0 -> 0.3.1 ``                                                            |
| [`8a9e3568`](https://github.com/NixOS/nixpkgs/commit/8a9e3568765e800eeac7a53573da4dc5d0b6c60d) | `` ray: 2.56.1 -> 2.57.0 ``                                                                              |
| [`f6068f86`](https://github.com/NixOS/nixpkgs/commit/f6068f86805bc277f6138aff72248d79e4062b6f) | `` virter: 1.1.0 -> 1.2.0 ``                                                                             |
| [`9259541b`](https://github.com/NixOS/nixpkgs/commit/9259541b1652dae633707ff840858fd397df66bc) | `` ungoogled-chromium: 151.0.7922.108-1 -> 151.0.7922.137-1 ``                                           |
| [`4097dbc2`](https://github.com/NixOS/nixpkgs/commit/4097dbc277a02c964172ab4647d50223c5bc9131) | `` chromium,chromedriver: 151.0.7922.108 -> 151.0.7922.137 ``                                            |
| [`6e76e11d`](https://github.com/NixOS/nixpkgs/commit/6e76e11deec272792042bcebddb63ce72724502f) | `` dokieli: fix license ``                                                                               |
| [`4ba02f5c`](https://github.com/NixOS/nixpkgs/commit/4ba02f5cd06a6501facad8d6a78e1c2472aaf1df) | `` rerun: 0.35.0 -> 0.36.0 ``                                                                            |
| [`e9f74047`](https://github.com/NixOS/nixpkgs/commit/e9f74047295afcdec2f0f33c65b7012c289197bd) | `` python3Packages.datafusion: 53.0.0 -> 54.0.0 ``                                                       |
| [`411696c4`](https://github.com/NixOS/nixpkgs/commit/411696c4aaaed8f4488624fb82ccdbeb4c18e9b5) | `` rtorrent: 0.16.19 -> 0.16.20 ``                                                                       |
| [`3fadb70a`](https://github.com/NixOS/nixpkgs/commit/3fadb70abfcce2dfdb011bc4e15f9d7c25ec5202) | `` python3Packages.wandb: 0.28.1 -> 0.28.2 ``                                                            |
| [`7041f844`](https://github.com/NixOS/nixpkgs/commit/7041f844e23e4664b4b0218d02f6e93934c06a85) | `` tuigreet: enable __structuredAttrs ``                                                                 |
| [`28afa61d`](https://github.com/NixOS/nixpkgs/commit/28afa61defc1c1da754acc9ec3a890ccf23d00b9) | `` nix-direnv: meta: add changelog ``                                                                    |
| [`0cd0ea77`](https://github.com/NixOS/nixpkgs/commit/0cd0ea77c40b42599cea4431fc5dbacd696a56cb) | `` ncdu: meta: changelog: point to a specific release ``                                                 |
| [`48c02236`](https://github.com/NixOS/nixpkgs/commit/48c022362061a36cc3b5672df5f197a268ca6bda) | `` tuigreet: 0.9.1 -> 0.11.0, switch to GitHub org ``                                                    |
| [`b219f76d`](https://github.com/NixOS/nixpkgs/commit/b219f76d6b44b45bff9af3bfcacbe7da0d70ba92) | `` tuigreet: add NotAShelf as maintainer ``                                                              |
| [`7b9520ba`](https://github.com/NixOS/nixpkgs/commit/7b9520ba59cea97e03f2c0158fbfc6db75a29f9a) | `` tuigreet: add antoineco as maintainer ``                                                              |
| [`400e9758`](https://github.com/NixOS/nixpkgs/commit/400e97584b7371db384a1ed8163ca26bcb0e432d) | `` music-assistant: 2.9.10 -> 2.9.13 ``                                                                  |
| [`1fd7dbec`](https://github.com/NixOS/nixpkgs/commit/1fd7dbec4ea0efbc52c3ab5ef7829f73c1b9178c) | `` python3Packages.django-tenants: 3.12.0 -> 3.14.0 ``                                                   |
| [`6432c635`](https://github.com/NixOS/nixpkgs/commit/6432c6358d9441749c0567098be32236b4a4773a) | `` croncpp: 2023.03.30 -> 2026.08.12 ``                                                                  |
| [`802010da`](https://github.com/NixOS/nixpkgs/commit/802010da2627c089deba8a570aba7e8cbd73c227) | `` Revert "ultrastardx: use ffmpeg 8" ``                                                                 |
| [`f4c9045c`](https://github.com/NixOS/nixpkgs/commit/f4c9045c9bdf53dd896f73526a2bb1a7048b82d9) | `` nerva: 1.64.2 -> 1.64.3 ``                                                                            |
| [`fcd98502`](https://github.com/NixOS/nixpkgs/commit/fcd985026a1a2d74b09d35607ca1305f1740ba8f) | `` python3Packages.cyclonedx-python-lib: 11.11.1 -> 11.11.2 ``                                           |
| [`670c8671`](https://github.com/NixOS/nixpkgs/commit/670c8671c46bd34bedac5be0ac1c50692275f9cc) | `` python3Packages.hishel: 1.3.0 -> 1.3.1 ``                                                             |
| [`565e111d`](https://github.com/NixOS/nixpkgs/commit/565e111d5405dc95eea270d9c5f0e7b51dccc0bf) | `` consul: 2.0.2 -> 2.0.3 ``                                                                             |
| [`35351a66`](https://github.com/NixOS/nixpkgs/commit/35351a664ce448390f6b84dd27540a71c4e81005) | `` vscode-extensions.databricks.databricks: 2.12.4 -> 2.13.0 ``                                          |
| [`f75e26b9`](https://github.com/NixOS/nixpkgs/commit/f75e26b9722e6363877deebd711e8a0e05c8135d) | `` chirpstack-mqtt-forwarder: 4.6.0 -> 4.6.1 ``                                                          |
| [`b93a86f9`](https://github.com/NixOS/nixpkgs/commit/b93a86f98378bc35c16bd0514ee8c3b635bff956) | `` lib.fileset: Check the common case first in the toSource filter ``                                    |
| [`c55c59d4`](https://github.com/NixOS/nixpkgs/commit/c55c59d46c89da53a95e5d159e87adc08f8589dc) | `` lib.fileset: Don't recurse into files in _normaliseTreeFilter ``                                      |
| [`0d9f8e4f`](https://github.com/NixOS/nixpkgs/commit/0d9f8e4f09512879350acada784fae28b2ef0d49) | `` lib.fileset: Optimise _unionTrees ``                                                                  |
| [`6560e0cb`](https://github.com/NixOS/nixpkgs/commit/6560e0cb793349caf91c3ea7f71e877171276ee7) | `` terraform-providers.sysdiglabs_sysdig: 3.9.0 -> 3.9.1 ``                                              |
| [`3794e492`](https://github.com/NixOS/nixpkgs/commit/3794e4929eb6bd2fba0534abec74295cd522859c) | `` keepassxc-go: 1.6.0 -> 1.7.0 ``                                                                       |
| [`194d2cb3`](https://github.com/NixOS/nixpkgs/commit/194d2cb355ce90d5be35a384ec52d9917e6f6bfc) | `` dokieli: 0-unstable-2026-05-08 -> 0-unstable-2026-08-10 ``                                            |
| [`69175e8e`](https://github.com/NixOS/nixpkgs/commit/69175e8ef2a69dba067dce79d423ac886b78c9b8) | `` openfga: 1.18.2 -> 1.18.3 ``                                                                          |
| [`2916b8bf`](https://github.com/NixOS/nixpkgs/commit/2916b8bf72a92f22ee8057b382a8804f81a9fb52) | `` python3Packages.fireworks-ai: 1.2.0 -> 1.2.8 ``                                                       |
| [`a0bf5ea7`](https://github.com/NixOS/nixpkgs/commit/a0bf5ea7b7d39933cfb699f9242436ac88324d07) | `` terraform-providers.splunk-terraform_signalfx: 9.33.0 -> 9.34.0 ``                                    |
| [`d68c8928`](https://github.com/NixOS/nixpkgs/commit/d68c8928093c9faca7013cd30805d0224405fef5) | `` cargo-flamegraph: 0.6.13 -> 0.6.14 ``                                                                 |
| [`394932b9`](https://github.com/NixOS/nixpkgs/commit/394932b9779de6e0683f1a56aa4b4c014ae4747f) | `` cargo-shear: 1.13.3 -> 1.13.4 ``                                                                      |
| [`0cc8218d`](https://github.com/NixOS/nixpkgs/commit/0cc8218d8ff233312bb5972b98e849f1b4469536) | `` rmatrix: init at 0.3.3 ``                                                                             |
| [`73f9aef2`](https://github.com/NixOS/nixpkgs/commit/73f9aef2219747d5f64933a7f8084515078fe1f2) | `` home-assistant-custom-components.plant: 2026.8.0 -> 2026.8.1 ``                                       |
| [`cd2ef41d`](https://github.com/NixOS/nixpkgs/commit/cd2ef41dff655d4360ee113bb11536a1adc709d6) | `` python3Packages.bambi: 0.19.0 -> 0.20.0 ``                                                            |
| [`cc294756`](https://github.com/NixOS/nixpkgs/commit/cc294756896d2eb595be6b5a5f5d8e5149968671) | `` python3Packages.blackjax: skip failing tests on aarch64-linux ``                                      |
| [`7cd9eeb2`](https://github.com/NixOS/nixpkgs/commit/7cd9eeb247c6a5c6445273e5b7095d1a5c521c24) | `` vscode-extensions.danielsanmedium.dscodegpt: 3.24.39 -> 3.24.43 ``                                    |
| [`80967a78`](https://github.com/NixOS/nixpkgs/commit/80967a78fac654f683f44ec17cba3ff313c5f18d) | `` cyan-skillfish-governor-smu: init at 0.4.12 ``                                                        |
| [`a146934e`](https://github.com/NixOS/nixpkgs/commit/a146934e677113ca24db34418c129229dbdf4ee1) | `` ultrastardx: 2026.6.0 -> 2026.8.0 ``                                                                  |
| [`7c28ade9`](https://github.com/NixOS/nixpkgs/commit/7c28ade9ce88bce642bc511e35878c875601817f) | `` python3Packages.credsweeper: 1.16.0 -> 1.17.4 ``                                                      |
| [`2f273211`](https://github.com/NixOS/nixpkgs/commit/2f27321178a6f8a936d830273580c13e0e6cb02c) | `` qt6Packages.fcitx5-qt: 5.1.13 -> 5.1.14 ``                                                            |
| [`5141a381`](https://github.com/NixOS/nixpkgs/commit/5141a3814dd0962fb96c4a4bb3612f0028995bc8) | `` python3Packages.pysquashfsimage: init at 0.9.0 ``                                                     |
| [`c7f78ae4`](https://github.com/NixOS/nixpkgs/commit/c7f78ae4b2f709eaa64cbc8c2e157bf9cdc8d44e) | `` python3Packages.ansi2image: patch version ``                                                          |
| [`a437cbec`](https://github.com/NixOS/nixpkgs/commit/a437cbec63f74801d7e8f361e91d3e7936bbe3b4) | `` calibre: cleanup ``                                                                                   |
| [`f26f0a9f`](https://github.com/NixOS/nixpkgs/commit/f26f0a9f6615b36c50141cbb33705be1bdac364c) | `` libretro-shaders-slang: 0-unstable-2026-08-03 -> 0-unstable-2026-08-08 ``                             |
| [`cfaa3dd0`](https://github.com/NixOS/nixpkgs/commit/cfaa3dd0a5ff4cf14079f16e766d22c290635134) | `` scenefx: add default version alias that was forgot in https://github.com/NixOS/nixpkgs/pull/539969 `` |
| [`ecdb9ba5`](https://github.com/NixOS/nixpkgs/commit/ecdb9ba506d6760ae810ffcb249a9397ed08f3d3) | `` libretro.snes9x: 0-unstable-2026-07-13 -> 0-unstable-2026-08-09 ``                                    |
| [`c503419d`](https://github.com/NixOS/nixpkgs/commit/c503419d3e02682403256f5a1d71cd553449f82d) | `` python3Packages.aiopnsense: 1.1.5 -> 1.1.7 ``                                                         |
| [`067ba025`](https://github.com/NixOS/nixpkgs/commit/067ba0257a84279c73829188a86b01814714b9aa) | `` python3Packages.aioghost: 0.4.22 -> 0.4.23 ``                                                         |
| [`d1f2e8b5`](https://github.com/NixOS/nixpkgs/commit/d1f2e8b5567692db4c548890a17a249cea3a7f45) | `` valeStyles.redhat: 673 -> 675 ``                                                                      |
| [`4e025b6c`](https://github.com/NixOS/nixpkgs/commit/4e025b6cc8617ae5408eb99d1ca2e0cb8ac41907) | `` stakk: 1.17.2 -> 1.19.0 ``                                                                            |
| [`a449bcb5`](https://github.com/NixOS/nixpkgs/commit/a449bcb56f9a6682d51e4022a30055768a945248) | `` python3Packages.txtai: 9.10.0 -> 9.12.0 ``                                                            |
| [`d29de272`](https://github.com/NixOS/nixpkgs/commit/d29de27237a8038a75c6bfd1bc4165905844b2c3) | `` python3Packages.databricks-sdk: 0.123.0 -> 0.127.0 ``                                                 |
| [`c8283512`](https://github.com/NixOS/nixpkgs/commit/c8283512b31646cba784792ffd46a3a0acd776ac) | `` pytr: 0.4.9 -> 0.4.10 ``                                                                              |
| [`f84cfa38`](https://github.com/NixOS/nixpkgs/commit/f84cfa3808a6c557841c61b6d97d04ac712dee2b) | `` python3Packages.tencentcloud-sdk-python: 3.1.154 -> 3.1.155 ``                                        |
| [`bce140c1`](https://github.com/NixOS/nixpkgs/commit/bce140c16e01256eacb14214ad8ae1753cc4fc79) | `` python3Packages.tencentcloud-sdk-python: 3.1.153 -> 3.1.154 ``                                        |
| [`5c11d74c`](https://github.com/NixOS/nixpkgs/commit/5c11d74cbd6b967a2ddba240c7194eabc0d86e57) | `` ghr-cli: 0.8.2 -> 0.9.0 ``                                                                            |
| [`263283be`](https://github.com/NixOS/nixpkgs/commit/263283be75d3da18c07c8c574640fa2fc464d82d) | `` python3Packages.fastmcp: 3.3.1 -> 3.4.7 ``                                                            |
| [`cd99a78c`](https://github.com/NixOS/nixpkgs/commit/cd99a78cd95b3b3eea1c6bd0f761f0ee5a53d218) | `` python3Packages.whenever: 0.10.4 -> 0.10.5 ``                                                         |
| [`38bcb898`](https://github.com/NixOS/nixpkgs/commit/38bcb89862aad6acd5969bdac2fa1443a8bdc471) | `` klayout: add gonsolo to maintainers ``                                                                |
| [`270ae2d7`](https://github.com/NixOS/nixpkgs/commit/270ae2d764d660b0fc80df76a0aa1a543fbe6adf) | `` klayout: 0.30.8 -> 0.30.10 ``                                                                         |
| [`0fdb88de`](https://github.com/NixOS/nixpkgs/commit/0fdb88dec84a9bedd70d8537fc44d1428e478739) | `` clj-kondo: 2026.08.03 -> 2026.08.04 ``                                                                |
| [`89a6fee5`](https://github.com/NixOS/nixpkgs/commit/89a6fee552c149cc21d7dead06b844ebbbaa95b4) | `` mobile-config-firefox: 4.6.0 -> 5.4.1 ``                                                              |
| [`5240fa59`](https://github.com/NixOS/nixpkgs/commit/5240fa596f240f1b19f6e8169d02e29713d05730) | `` readsb: 3.16.9 -> 3.16.16 ``                                                                          |
| [`41e401ae`](https://github.com/NixOS/nixpkgs/commit/41e401ae9fd81cf0e65c9b7a639c44050c3f9f99) | `` nixos/solaar: init ``                                                                                 |
| [`dca9cff0`](https://github.com/NixOS/nixpkgs/commit/dca9cff0db04c3c1f617f6af5a56caeba1841316) | `` miriway: 26.06.3 -> 26.08 ``                                                                          |
| [`da595499`](https://github.com/NixOS/nixpkgs/commit/da5954999df765879ec608ea93c037caa0a823d8) | `` nixos/kvrocks: init ``                                                                                |
| [`20d90972`](https://github.com/NixOS/nixpkgs/commit/20d9097277e0034b0da50569fe605148cea76e16) | `` music-assistant: fix update script after ruff update ``                                               |
| [`3b18d133`](https://github.com/NixOS/nixpkgs/commit/3b18d1333ce5a9912515b121e1c529cb7c812513) | `` troubadix: 26.7.2 -> 26.8.1 ``                                                                        |
| [`343afc88`](https://github.com/NixOS/nixpkgs/commit/343afc889fa4900f4525ac3a458add93a8d12e92) | `` ultrastardx: use ffmpeg 8 ``                                                                          |
| [`5ecbd2dd`](https://github.com/NixOS/nixpkgs/commit/5ecbd2dd0f599bea62bf8f6a4eef823866bc9a3a) | `` stackit-cli: 0.68.0 -> 0.70.0 ``                                                                      |
| [`b208dfad`](https://github.com/NixOS/nixpkgs/commit/b208dfad3552c66cc39b7e3c34059f03c7d304d2) | `` python3Packages.zhong-hong-hvac: 1.0.15 -> 1.0.18 ``                                                  |
| [`6449fc65`](https://github.com/NixOS/nixpkgs/commit/6449fc65ca6fded9842b6e433c316aa8a537fe8b) | `` python3Packages.iocx: 0.7.5 -> 0.7.6 ``                                                               |
| [`8f2e1587`](https://github.com/NixOS/nixpkgs/commit/8f2e15871811625bfbae353436b6c0385a8cb53e) | `` ext4fuse: drop ``                                                                                     |
| [`d72e7973`](https://github.com/NixOS/nixpkgs/commit/d72e7973ccec068e49e6a444dcbe1b8eb51fa0e1) | `` davinci-resolve: 21.0.3 -> 21.0.4 ``                                                                  |
| [`6eb0587f`](https://github.com/NixOS/nixpkgs/commit/6eb0587f07478721aff3c422253ba66b16e34b1a) | `` nixos/eternal-terminal: add opt-in telemetry setting ``                                               |
| [`64ce5ecf`](https://github.com/NixOS/nixpkgs/commit/64ce5ecfd1b90c7293478e97a079a943ff6d06b0) | `` nixos/eternal-terminal: fix systemd service mis-tracks etserver --daemon ``                           |
| [`e67448e7`](https://github.com/NixOS/nixpkgs/commit/e67448e7d43d83dbabab1ee53277c7bd15788a32) | `` postgresqlPackages.pgactive: init at 2.1.8 ``                                                         |
| [`50faf351`](https://github.com/NixOS/nixpkgs/commit/50faf351c1c70f12df2e631ca2561abd24bff3b8) | `` python3Packages.mlflow: relax cryptography ``                                                         |
| [`f72c9dbd`](https://github.com/NixOS/nixpkgs/commit/f72c9dbd56bea9402ab7a267917bbaf8a1db7c6c) | `` mango: 0.15.6 -> 0.16.0 ``                                                                            |
| [`322807d7`](https://github.com/NixOS/nixpkgs/commit/322807d75b39715c6f6391d12414d5ea9e7be57d) | `` zensical: 0.0.52 -> 0.0.53 ``                                                                         |
| [`8ce3147b`](https://github.com/NixOS/nixpkgs/commit/8ce3147b8bdb6883bad7d7c512da72171c0defbc) | `` metapac: 0.10.0 -> 0.10.1 ``                                                                          |
| [`c599c8fc`](https://github.com/NixOS/nixpkgs/commit/c599c8fcf12b835d2bc81dce0aa37fb866df13dc) | `` python3Packages.pycdlib: 1.16.0 -> 1.20.0 ``                                                          |
| [`0d2e396d`](https://github.com/NixOS/nixpkgs/commit/0d2e396d2746482752e09f1132acf271c9854415) | `` fabric-ai: 1.4.468 -> 1.4.470 ``                                                                      |
| [`bb185485`](https://github.com/NixOS/nixpkgs/commit/bb185485ddc0e0ee1420dd7006d1a4c68bb7214f) | `` updatecli: 0.119.0 -> 0.120.0 ``                                                                      |
| [`925b2d2a`](https://github.com/NixOS/nixpkgs/commit/925b2d2ac647c39f9220cb813f66b0fec79fce41) | `` beekeeper-studio: 5.9.3 -> 6.0.0 ``                                                                   |
| [`e2603267`](https://github.com/NixOS/nixpkgs/commit/e2603267ecc272def037c969df8d845e0cc56f8a) | `` cargo-chef: 0.1.77 -> 0.1.78 ``                                                                       |
| [`ba9a1ef6`](https://github.com/NixOS/nixpkgs/commit/ba9a1ef640f9c5afae08095696e6796c82d7f38f) | `` python3Packages.langgraph-runtime-inmem: 0.31.2 -> 0.32.3 ``                                          |
| [`89322a3a`](https://github.com/NixOS/nixpkgs/commit/89322a3a768c641f39668c8eb8b651fdf95125aa) | `` vscode-extensions.anthropic.claude-code: 2.1.227 -> 2.1.228 ``                                        |
| [`865b874e`](https://github.com/NixOS/nixpkgs/commit/865b874ef8da2e662658aad8349b58aef9e1bd4d) | `` python3Packages.python-bsblan: 6.1.7 -> 6.1.8 ``                                                      |
| [`6df59e4f`](https://github.com/NixOS/nixpkgs/commit/6df59e4f296f179bff54143d17f38a8b8bc8c108) | `` discord: update variouse ``                                                                           |
| [`7185ba3f`](https://github.com/NixOS/nixpkgs/commit/7185ba3fe92309ef498165075d24c6049d044f9c) | `` claude-code: 2.1.227 -> 2.1.228 ``                                                                    |
| [`b63bb26d`](https://github.com/NixOS/nixpkgs/commit/b63bb26d749a43e97c580d80aad816833651a2a9) | `` uavs3d: 1.1-unstable-2025-12-13 -> 1.2 ``                                                             |
| [`38772d18`](https://github.com/NixOS/nixpkgs/commit/38772d18af7d244fb9d661223be6012aca100110) | `` namespace-cli: 0.0.551 -> 0.0.556 ``                                                                  |
| [`19c14e52`](https://github.com/NixOS/nixpkgs/commit/19c14e525d16c672b6d5ff3a5820aed006ff27af) | `` terraform-providers.ucloud_ucloud: 1.39.5 -> 1.39.6 ``                                                |
| [`00ac2cdc`](https://github.com/NixOS/nixpkgs/commit/00ac2cdce22a62e7e108bff84fcd224e91a4dbcf) | `` renovate: 44.13.1 -> 44.24.3 ``                                                                       |
| [`545f3439`](https://github.com/NixOS/nixpkgs/commit/545f3439a80a03074cd321cbac0a81c0ab705657) | `` vscode-extensions.tekumara.typos-vscode: 0.1.51 -> 0.1.55 ``                                          |
| [`5291ed8f`](https://github.com/NixOS/nixpkgs/commit/5291ed8f12e674a70404af7b9faba87d7178003b) | `` google-chrome: 151.0.7922.108 -> 151.0.7922.137 ``                                                    |
| [`f9116f7a`](https://github.com/NixOS/nixpkgs/commit/f9116f7aeb1d024559e7507a0e01358cb20ebac6) | `` piped: 0-unstable-2026-07-06 -> 0-unstable-2026-08-09 ``                                              |
| [`c66485ad`](https://github.com/NixOS/nixpkgs/commit/c66485ad1a536ba72e3548b6ceae0001f036e51b) | `` kingfisher: 1.110.0 -> 1.113.0 ``                                                                     |
| [`f8275ea7`](https://github.com/NixOS/nixpkgs/commit/f8275ea777954adc826f4a8bdb7f8798969949f5) | `` python3Packages.oelint-data: 1.5.13 -> 1.5.14 ``                                                      |
| [`d0b6ee2a`](https://github.com/NixOS/nixpkgs/commit/d0b6ee2a9e242c4c032990cbac2e4d296b44e0ba) | `` python3Packages.llama-cpp-python: unpin gcc13 for cuda ``                                             |
| [`22488257`](https://github.com/NixOS/nixpkgs/commit/22488257857a1eecbd2957e0360eaa2b76f1e35a) | `` python3Packages.gardena-bluetooth: 2.9.0 -> 2.10.1 ``                                                 |
| [`707b18a1`](https://github.com/NixOS/nixpkgs/commit/707b18a12a509808ad0a22b5a76c63fae81ebe09) | `` python3Packages.uhashring: 2.4 -> 2.5 ``                                                              |
| [`3296d433`](https://github.com/NixOS/nixpkgs/commit/3296d4339a2392023885f074c18d02275506b25c) | `` maintainers: add sjcobb ``                                                                            |
| [`378a3ceb`](https://github.com/NixOS/nixpkgs/commit/378a3cebc7675c31efddb657e46ee444593d6bf8) | `` openwith: remove ``                                                                                   |
| [`d14f4174`](https://github.com/NixOS/nixpkgs/commit/d14f4174c601a2d1d19172b36c2e77bf0d877813) | `` confy-tui: 3.1.0 -> 3.1.1 ``                                                                          |
| [`63f67799`](https://github.com/NixOS/nixpkgs/commit/63f6779944770dd88623758e04d772ed849708bd) | `` python3Packages.apache-tvm-ffi: 0.1.13-post2 -> 0.1.13-post3 ``                                       |
| [`28ff0764`](https://github.com/NixOS/nixpkgs/commit/28ff0764fabc0215c4e018f4eb23a5db1ad83b5b) | `` gxmatcheq-lv2: unpin gcc13, fix build with modern gcc ``                                              |
| [`962461d7`](https://github.com/NixOS/nixpkgs/commit/962461d7f24cb9b3575ef41853f7bdc78f36b9a7) | `` mricron: drop ``                                                                                      |
| [`20943d75`](https://github.com/NixOS/nixpkgs/commit/20943d752fda9de35766574b5f59f72deca8f060) | `` lxsession: use gtk3 ``                                                                                |
| [`931b99d8`](https://github.com/NixOS/nixpkgs/commit/931b99d8e92dcbefc82db5570a0624a12851b301) | `` lxrandr: force-enable gtk3 ``                                                                         |
| [`2c0b209d`](https://github.com/NixOS/nixpkgs/commit/2c0b209d46d033b7d27a7048180a664d5cc0a5cc) | `` roslyn-ls: 5.11.0-1.26379.2 -> 5.11.0-1.26380.4 ``                                                    |
| [`4de109f1`](https://github.com/NixOS/nixpkgs/commit/4de109f1443f138b9e67f129e584155c378251b8) | `` libunique: drop ``                                                                                    |
| [`5ff30b82`](https://github.com/NixOS/nixpkgs/commit/5ff30b8211df16b31d552c8618e21ed32f6f5722) | `` libunique3: migrate to by-name ``                                                                     |
| [`a36bbee9`](https://github.com/NixOS/nixpkgs/commit/a36bbee9d2773a988117bbb1d37b5559c67e385b) | `` gwyddion: remove libunique support ``                                                                 |
| [`c77b924e`](https://github.com/NixOS/nixpkgs/commit/c77b924eeb680cf997b776b3b9c2f5c40c4c1d73) | `` home-assistant-custom-components.scene_presets: 2.3.3 -> 2.4.0 ``                                     |
| [`b5d3a9ba`](https://github.com/NixOS/nixpkgs/commit/b5d3a9bafa72a67d1d58d383f30ba825d3a814ee) | `` liteparse: 2.8.0 -> 2.11.1 ``                                                                         |
| [`e68b0f85`](https://github.com/NixOS/nixpkgs/commit/e68b0f858d33762fbdab9b42047010742f5c4c1c) | `` scalafmt: ensure installCheckPhase runs ``                                                            |
| [`ceb50670`](https://github.com/NixOS/nixpkgs/commit/ceb506709d9c89948f288ec9f83056616a3045af) | `` home-assistant-custom-lovelace-modules.material-you-utilities: 2.1.23 -> 2.1.24 ``                    |
| [`31abb239`](https://github.com/NixOS/nixpkgs/commit/31abb2398d183ba4e1be33c78de732bb0b9e1aad) | `` openscadPackages.bosl: init at unstable-2023-02-19 ``                                                 |
| [`26082fff`](https://github.com/NixOS/nixpkgs/commit/26082fffde56bdfbaf1ba69d843618acd2a15cd8) | `` python3Packages.pyimouapi: 1.3.3 -> 1.3.4 ``                                                          |
| [`84b3afd4`](https://github.com/NixOS/nixpkgs/commit/84b3afd4618f738787b84fbca498ce3a86ddc77f) | `` automatic-timezoned: 2.0.151 -> 2.0.153 ``                                                            |
| [`3953abf6`](https://github.com/NixOS/nixpkgs/commit/3953abf6d99329d3a51a3574f2f577c1c7244987) | `` opengist: 1.15.0 -> 1.15.1 ``                                                                         |
| [`5950d118`](https://github.com/NixOS/nixpkgs/commit/5950d11808f47497203abf12e2b7adcd9f244cc5) | `` poptracker: 0.35.3 -> 0.35.4 ``                                                                       |
| [`c64f1e85`](https://github.com/NixOS/nixpkgs/commit/c64f1e856d1cb4106a906a12b0016f104e2d4e56) | `` openttd-jgrpp: 0.73.0 -> 0.73.1 ``                                                                    |
| [`3163e8b1`](https://github.com/NixOS/nixpkgs/commit/3163e8b153f3c368e60bade01b4af60ed060f9fe) | `` microcode-intel: 20260512 -> 20260811 ``                                                              |
| [`46ee4a41`](https://github.com/NixOS/nixpkgs/commit/46ee4a41c51e956eee8f9f05a12e4cd9a65048b5) | `` jotta-cli: 0.17.159692 -> 0.17.176206 ``                                                              |
| [`aa6dc7f0`](https://github.com/NixOS/nixpkgs/commit/aa6dc7f0a08ea6ddaf5ce3208ba2c5c2600458a9) | `` beammp-launcher: 2.8.0 -> 2.8.1 ``                                                                    |
| [`dfac2fbb`](https://github.com/NixOS/nixpkgs/commit/dfac2fbb9aed92bc49e38668e1b37c27d3272c0b) | `` cargo-lock: 11.0.1 -> 11.1.0 ``                                                                       |
| [`48e99d33`](https://github.com/NixOS/nixpkgs/commit/48e99d332d990997d6e33701f1bde7ca8e4271b9) | `` snooze: 0.5.1 -> 0.6 ``                                                                               |
| [`2d0d6fdf`](https://github.com/NixOS/nixpkgs/commit/2d0d6fdff39e79099759592fe61c31fd3597fa44) | `` undertalemodcli: init at 0.9.1.2 ``                                                                   |
| [`abbb49e2`](https://github.com/NixOS/nixpkgs/commit/abbb49e258b2383d3d2d42d4149654fa7268f052) | `` binaryen: 130 -> 131 ``                                                                               |
| [`a9cb6084`](https://github.com/NixOS/nixpkgs/commit/a9cb6084f7c3d3c3be462680322bc24f530ed4ee) | `` communique: 1.3.0 -> 1.3.1 ``                                                                         |
| [`cc57a729`](https://github.com/NixOS/nixpkgs/commit/cc57a7292d66ac1a85e5dcc9a7ba90cdaaf538a0) | `` cloudquery: 6.41.0 -> 6.41.1 ``                                                                       |
| [`ffc0540d`](https://github.com/NixOS/nixpkgs/commit/ffc0540dd4b7949da7a6b817f5ee9c3afde32b3f) | `` polychromatic: 0.9.7 -> 0.9.8 ``                                                                      |
| [`06e90804`](https://github.com/NixOS/nixpkgs/commit/06e908049c706fa7d67eadc96c943ef31901de35) | `` golds: 0.8.5 -> 0.8.7 ``                                                                              |
| [`1bdd4cb6`](https://github.com/NixOS/nixpkgs/commit/1bdd4cb6be605653c77e6d8864cc53b53cbdc78b) | `` terraform-providers.spacelift-io_spacelift: 1.52.4 -> 1.53.5 ``                                       |
| [`dc2baa57`](https://github.com/NixOS/nixpkgs/commit/dc2baa571c9b736b00c28bbe42113c77648f75b4) | `` shopify-cli: 4.6.0 -> 4.6.1 ``                                                                        |
| [`89f8a8e8`](https://github.com/NixOS/nixpkgs/commit/89f8a8e8626e736dde0dcfa80e6f09829d49a748) | `` solanum: 0-unstable-2026-06-23 -> 0-unstable-2026-07-26 ``                                            |
| [`fc6e5561`](https://github.com/NixOS/nixpkgs/commit/fc6e55614c8b4de69352d30b32abaeb3f9ab13ae) | `` grafanaPlugins.grafana-lokiexplore-app: 2.4.0 -> 2.5.0 ``                                             |
| [`50406d32`](https://github.com/NixOS/nixpkgs/commit/50406d32fa05313b5084c3817f1e17afcd15edcf) | `` python3Packages.aioimmich: 0.16.3 -> 0.17.0 ``                                                        |
| [`aeeec63b`](https://github.com/NixOS/nixpkgs/commit/aeeec63b7661c3e3884c52c6fa540d8d782431a8) | `` python3Packages.arviz: 1.2.0 -> 1.3.0 ``                                                              |
| [`2f59d25e`](https://github.com/NixOS/nixpkgs/commit/2f59d25ece8f8e116fcf6cc60343998fe8b9c3ff) | `` exegol: 5.1.10 -> 5.1.11 ``                                                                           |
| [`8e6b420d`](https://github.com/NixOS/nixpkgs/commit/8e6b420d17ee45beb41bbea9714e6030dee607f1) | `` python3Packages.stripe: 15.4.0 -> 15.5.0 ``                                                           |
| [`02eb1d46`](https://github.com/NixOS/nixpkgs/commit/02eb1d46177e43f53f4bfd11342b899ffe1cc8d5) | `` maintainers: add dibenzepin to squawk ``                                                              |
| [`f382cadf`](https://github.com/NixOS/nixpkgs/commit/f382cadf1008ebeb86645804f9ba7d1a5d2b1f15) | `` everest: 6397 -> 6458 ``                                                                              |
| [`5cb27c2c`](https://github.com/NixOS/nixpkgs/commit/5cb27c2c384488e5bece4c4924a2c942fbf24eb7) | `` maintainers: move poopsicles to dibenzepin ``                                                         |
| [`1ad42c2b`](https://github.com/NixOS/nixpkgs/commit/1ad42c2b62752bf998c3102046749edebb6fb358) | `` scalafmt: add agilesteel as maintainer ``                                                             |
| [`06d0681d`](https://github.com/NixOS/nixpkgs/commit/06d0681d197de472bc9f6f06802fc87ac49d9311) | `` terraform-providers.aliyun_alicloud: 1.286.0 -> 1.288.0 ``                                            |
| [`5f2d8b5f`](https://github.com/NixOS/nixpkgs/commit/5f2d8b5fa2f032dc8387d6632ecde4ade487462b) | `` python3Packages.hist: 2.10.1 -> 2.11.0 ``                                                             |
| [`f326b8cc`](https://github.com/NixOS/nixpkgs/commit/f326b8cc2fe5af9d76c429d25d662d5a2cdb2e02) | `` smlnjBootstrap: remove ``                                                                             |
| [`81a2faac`](https://github.com/NixOS/nixpkgs/commit/81a2faac1fa2d2f70f2df64f05781ea1295c88f9) | `` hyprlandPlugins.hypr-darkwindow: 0.56.1 -> 0.56.2 ``                                                  |
| [`9118c9c5`](https://github.com/NixOS/nixpkgs/commit/9118c9c50e8d36160e38d04b63941b681db79c25) | `` python3Packages.pykerberos: set meta.homepage ``                                                      |
| [`a8e168b0`](https://github.com/NixOS/nixpkgs/commit/a8e168b0695ba0e1960738aac6bf3b29dc434a97) | `` python3Packages.pykerberos: use finalAttrs ``                                                         |
| [`5885e812`](https://github.com/NixOS/nixpkgs/commit/5885e812e4f7b964577ede585c7dad5259a70396) | `` virtnbdbackup: 2.48 -> 2.49 ``                                                                        |
| [`11f2f7d2`](https://github.com/NixOS/nixpkgs/commit/11f2f7d20d35bbd3ccd60265afe0360549c4642c) | `` python3Packages.pykerberos: migrate to pyproject ``                                                   |
| [`6d602ca6`](https://github.com/NixOS/nixpkgs/commit/6d602ca683634fa8193dce8b4b3d5d3de1d562a1) | `` python3Packages.pyjsparser: remove uneeded let block ``                                               |
| [`1c9a156d`](https://github.com/NixOS/nixpkgs/commit/1c9a156d95632a9d4e7ad87dd1e7ebde8494cb75) | `` python3Packages.pyjsparser: migrate to pyproject ``                                                   |
| [`d578214c`](https://github.com/NixOS/nixpkgs/commit/d578214c2746c7830918777a16d45074795ac37a) | `` matrix-continuwuity: 26.7.2 -> 26.7.3 ``                                                              |
| [`6821d5f4`](https://github.com/NixOS/nixpkgs/commit/6821d5f434cb4243ead3e8bc5bab90d7c1ca5fb4) | `` run-npush: use pname and version instead of name ``                                                   |
| [`8dc34021`](https://github.com/NixOS/nixpkgs/commit/8dc340217f29fb834d0062111331b5b4ee0c054c) | `` confclerk: enable darwin support ``                                                                   |
| [`abd3c31d`](https://github.com/NixOS/nixpkgs/commit/abd3c31da6c3da2a287271d6c026df15ea957715) | `` gokrazy: add update script ``                                                                         |
| [`28976acc`](https://github.com/NixOS/nixpkgs/commit/28976accd56d5208644c45f9fdc3f33f5129748f) | `` aks-mcp-server: 0.0.19 -> 0.0.20 ``                                                                   |
| [`4b39738c`](https://github.com/NixOS/nixpkgs/commit/4b39738cc43a989f0380563f304e26b6bd7fa1a4) | `` bind: fix riscv64-linux build ``                                                                      |
| [`afa5cff6`](https://github.com/NixOS/nixpkgs/commit/afa5cff636fe6c607da7bd54047036a6eabbf206) | `` ioquake3: 0-unstable-2025-05-15 -> 0-unstable-2026-07-19 ``                                           |
| [`0949151f`](https://github.com/NixOS/nixpkgs/commit/0949151f36f81cb13be43ac44ce27c043e084194) | `` nixos/tests/matrix-continuwuity: wrap sync filter in filter data class ``                             |
| [`1d45a37e`](https://github.com/NixOS/nixpkgs/commit/1d45a37ea83d64d54237ba5c15a33ef15a48d4e8) | `` grafanaPlugins.grafana-opensearch-datasource: 2.34.0 -> 2.34.3 ``                                     |
| [`6c666263`](https://github.com/NixOS/nixpkgs/commit/6c666263242f7c990cbde760d2cd27fb8e8e1e55) | `` dapr-cli: 1.18.0 -> 1.18.1 ``                                                                         |
| [`c303ba31`](https://github.com/NixOS/nixpkgs/commit/c303ba319bea664a969ca900989fb361eff49958) | `` typora: 1.14.8 -> 1.14.9 ``                                                                           |
| [`76900bb1`](https://github.com/NixOS/nixpkgs/commit/76900bb129686822df431b7e9bfedd113e7f9f4c) | `` gtkclipblock: remove gtk2 support ``                                                                  |
| [`12c5a31d`](https://github.com/NixOS/nixpkgs/commit/12c5a31da8d2e744d54315f92ef3e18d46d876f8) | `` eden: pin httplib input ``                                                                            |
| [`aa81653b`](https://github.com/NixOS/nixpkgs/commit/aa81653b540d4d8d8932d2c1a7eeb45d35be83ff) | `` linuxKernel.kernels.linux_zen: 7.1.5 -> 7.1.8 ``                                                      |
| [`34e1b14e`](https://github.com/NixOS/nixpkgs/commit/34e1b14e37b5b010d080e5e0b5832f1e1b4463ed) | `` dutctl: 1.0.0-alpha.1-unstable-2026-07-29 -> 1.0.0-alpha.1-unstable-2026-08-06 ``                     |
| [`ea631480`](https://github.com/NixOS/nixpkgs/commit/ea63148036ddac8edb80e18baad431c7db81475f) | `` libdeltachat: 2.57.0 -> 2.58.0 ``                                                                     |
| [`06cedd78`](https://github.com/NixOS/nixpkgs/commit/06cedd78e574e672acfaa812fe9a9b86fbe1fcf9) | `` nixos/tests/verity-store: fix ``                                                                      |
| [`26bf21c7`](https://github.com/NixOS/nixpkgs/commit/26bf21c7f9bd97922145be9332394a0430480543) | `` python3Packages.openccu-loom-client: fix tests on Darwin ``                                           |
| [`19f63a1d`](https://github.com/NixOS/nixpkgs/commit/19f63a1dfca6f931e794cbdf39791adefc3e7fe1) | `` python3Packages.pymedio: drop ``                                                                      |
| [`04b55767`](https://github.com/NixOS/nixpkgs/commit/04b557670b5c726c808e00e938a0ad5cbd4ed621) | `` python3Packages.telnetlib3: 4.0.5 -> 5.0.0 ``                                                         |
| [`e24be8ac`](https://github.com/NixOS/nixpkgs/commit/e24be8acf69a89d6be1b8ac9d2885fb20e88a5b5) | `` python3Packages.aiohomematic: fix tests on Darwin ``                                                  |
| [`6e20dd88`](https://github.com/NixOS/nixpkgs/commit/6e20dd888327d4a44864b0b301aaff30523d902a) | `` python3Packages.ical: fix tests on Darwin ``                                                          |
| [`1d967f49`](https://github.com/NixOS/nixpkgs/commit/1d967f495ade99f4c9de1f8cab6c43762d67e5f8) | `` devin-desktop: 3.6.27 -> 3.7.16 ``                                                                    |
| [`59c9f732`](https://github.com/NixOS/nixpkgs/commit/59c9f73217ca1ee01a3d3c49c45cf48ded5d9fcc) | `` bottles-unwrapped: disable obs-vkcapture by default and add feature flag ``                           |
| [`02658096`](https://github.com/NixOS/nixpkgs/commit/02658096238d11331ced62671af7327e55e23a54) | `` databricks-cli: 1.10.0 -> 1.11.0 ``                                                                   |
| [`118dfb89`](https://github.com/NixOS/nixpkgs/commit/118dfb89f5145d06cf12a009f1f20f16edd0d8d0) | `` terraform-providers.fortinetdev_fortios: 1.25.0 -> 1.26.0 ``                                          |
| [`7462ad77`](https://github.com/NixOS/nixpkgs/commit/7462ad77be180bd5033cd4d8bbf0b91047c7dda2) | `` pgdog: 0.1.49 -> 0.1.52 ``                                                                            |
| [`64fc459b`](https://github.com/NixOS/nixpkgs/commit/64fc459b37696b0d7f4ad334cdef4339ba641354) | `` reindeer: 2026.07.27.00 -> 2026.08.10.00 ``                                                           |
| [`341fa529`](https://github.com/NixOS/nixpkgs/commit/341fa5291a84be77b7ed0f843e4d3db8dfbda05f) | `` postgresqlPackages.pglite_fusion: init at 0.0.7 ``                                                    |
| [`061ee138`](https://github.com/NixOS/nixpkgs/commit/061ee13868222cb4f5cc521d083437608d3cb6f0) | `` txtpbfmt: 0-unstable-2026-07-16 -> 0-unstable-2026-08-03 ``                                           |
| [`8bc63979`](https://github.com/NixOS/nixpkgs/commit/8bc63979bcf6cf4b6ac2e23b992668eb0b743fcb) | `` museum: 1.3.59 -> 1.3.61 ``                                                                           |
| [`2965692c`](https://github.com/NixOS/nixpkgs/commit/2965692c8e39534bdcddc62ec166c3834a3f4753) | `` notepad-next: remove broken mark on aarch64-linux ``                                                  |
| [`2c5cf4e3`](https://github.com/NixOS/nixpkgs/commit/2c5cf4e3f85ce795f9a93272fc8cec78896094ce) | `` rclip: 3.2.5 -> 3.3.0 ``                                                                              |
| [`b2d2067d`](https://github.com/NixOS/nixpkgs/commit/b2d2067d5367147cc7a775a4e780588b0cf65e76) | `` hydrus: update dependecies, set mainProgram ``                                                        |
| [`4cb2a3be`](https://github.com/NixOS/nixpkgs/commit/4cb2a3be50c272eeebd9b57fa2f9696e84090b6d) | `` python3Packages.pillow-jxl-plugin: init at 1.3.8 ``                                                   |
| [`a595896f`](https://github.com/NixOS/nixpkgs/commit/a595896fbfe7e5fac6f589701b9ec8f4dfb96034) | `` eliza: 0-unstable-2026-07-28 -> 0-unstable-2026-08-10 ``                                              |
| [`ebedad98`](https://github.com/NixOS/nixpkgs/commit/ebedad980903cb8aa56a9313503187ec7b3f65e5) | `` mold-unwrapped: 2.41.0 -> 2.42.0 ``                                                                   |
| [`9137a7cd`](https://github.com/NixOS/nixpkgs/commit/9137a7cd08fc0609b94391279c70e86dd0c2fe58) | `` swift: do not use passAsFile for buildCommand ``                                                      |
| [`dde5a19f`](https://github.com/NixOS/nixpkgs/commit/dde5a19ff85bf16e7e206591d6be4526c7718ae0) | `` yet-another-cloudwatch-exporter: init at 0.67.0 ``                                                    |
| [`b5446eb7`](https://github.com/NixOS/nixpkgs/commit/b5446eb79e3cd62be193585df5501dca8be7d794) | `` coroot: 1.24.3 -> 1.24.4 ``                                                                           |
| [`fd29dd60`](https://github.com/NixOS/nixpkgs/commit/fd29dd6058930948840e2a680cc9ddae85a17ba2) | `` python3Packages.monzopy: 1.6.0 -> 1.8.0 ``                                                            |
| [`b582e275`](https://github.com/NixOS/nixpkgs/commit/b582e2757dd68896910ecffcfe8c609e4584f984) | `` firefox-bin-unwrapped: 153.0.3 -> 153.0.4 ``                                                          |
| [`4c1cb283`](https://github.com/NixOS/nixpkgs/commit/4c1cb283d8b8ba18f67894dd3cd97bce93b37b10) | `` firefox-unwrapped: 153.0.3 -> 153.0.4 ``                                                              |
| [`09e38037`](https://github.com/NixOS/nixpkgs/commit/09e380379bf5dd25952629913f6884058db85b28) | `` models-dev: restructure derivation ``                                                                 |
| [`8b1d9199`](https://github.com/NixOS/nixpkgs/commit/8b1d9199ece32a862c3505c3ec9748c3827d4234) | `` python3Packages.deepspeed: 0.19.2 -> 0.19.5 ``                                                        |
| [`13615fe5`](https://github.com/NixOS/nixpkgs/commit/13615fe56f775625fcadfe0c8170547d0029bda0) | `` python3Packages.array-api-compat: set CUPY_CACHE_DIR to fix tests ``                                  |
| [`7e7ae52d`](https://github.com/NixOS/nixpkgs/commit/7e7ae52dd316e1a31c8db7005adfae9f993f8445) | `` python3Packages.cupy: 14.0.1 -> 14.1.1 ``                                                             |
| [`5a4f5aaf`](https://github.com/NixOS/nixpkgs/commit/5a4f5aaf7b6ed9530844dcb499d171f7f61b14c1) | `` tsx: 4.23.1 -> 4.23.12 ``                                                                             |
| [`0da98c7f`](https://github.com/NixOS/nixpkgs/commit/0da98c7f0b0fdad01dee2dd17403c62fa816be2d) | `` gitkraken: 12.3.1 -> 12.4.0 ``                                                                        |
| [`adaf6b7d`](https://github.com/NixOS/nixpkgs/commit/adaf6b7d765571367ea664cf79519634c03bd210) | `` libxfce4windowing: 4.20.6 -> 4.20.7 ``                                                                |
| [`4ba90a04`](https://github.com/NixOS/nixpkgs/commit/4ba90a04cd41afcca4c3fed45770cc8e5a139b37) | `` json-sort-cli: 3.0.2 -> 3.0.3 ``                                                                      |
| [`d127f0e4`](https://github.com/NixOS/nixpkgs/commit/d127f0e4be18c03b281c8d4382867d0b4b420486) | `` python3Packages.mitsubishi-comfort: 0.5.1 -> 0.5.2 ``                                                 |
| [`5f01d23a`](https://github.com/NixOS/nixpkgs/commit/5f01d23a536b2f34ecf2822e1278a3ee2daa587a) | `` freifunk-meshviewer: 13.1.0 -> 13.2.0 ``                                                              |
| [`25ff99fc`](https://github.com/NixOS/nixpkgs/commit/25ff99fc53f01b8b52c58502aedeeca7e89af1cb) | `` python3Packages.google-cloud-tasks: 2.23.0 -> 2.24.0 ``                                               |
| [`cd967b5c`](https://github.com/NixOS/nixpkgs/commit/cd967b5c892df8cae58a29b9ae804c4d59c88d3d) | `` gnome-nettool: drop ``                                                                                |
| [`59de06ab`](https://github.com/NixOS/nixpkgs/commit/59de06abedd6d064437bbde68835a8204faf3b9c) | `` bobgen: 0.49.0 -> 0.50.0 ``                                                                           |
| [`7d748a53`](https://github.com/NixOS/nixpkgs/commit/7d748a53215e656e461c211b0d0e6420b9123799) | `` turborepo-remote-cache: 2.11.5 -> 2.12.0 ``                                                           |
| [`e8ed7090`](https://github.com/NixOS/nixpkgs/commit/e8ed7090856c0638342260e468b5ec5985907ae1) | `` proton-pass-cli: 2.2.6 -> 2.3.0 ``                                                                    |
| [`08c52bfd`](https://github.com/NixOS/nixpkgs/commit/08c52bfd7ed341c4aeff087262eccd858fdaa9ec) | `` python3Packages.weaviate-client: 4.22.0 -> 4.23.0 ``                                                  |
| [`ddbd417c`](https://github.com/NixOS/nixpkgs/commit/ddbd417cda290a4bd7c4206d480fa430976b4bff) | `` alcove: add `__structuredAtttrs` and `strictDeps` attributes ``                                       |
| [`e8edcb69`](https://github.com/NixOS/nixpkgs/commit/e8edcb696e0532774577ffc02a29c518e9151366) | `` models-dev: sdk-v0.0.5-unstable-2026-08-04 -> sdk-v0.0.5-unstable-2026-08-11 ``                       |
| [`8d4ecf6d`](https://github.com/NixOS/nixpkgs/commit/8d4ecf6dfa2c93f3b743526a0967e8e6835b595e) | `` gavin-bc: add `__structuredAtttrs` and `strictDeps` attributes ``                                     |
| [`b607b6fa`](https://github.com/NixOS/nixpkgs/commit/b607b6fa72be3675324d3c69b4af72e1a826febe) | `` subler: add `__structuredAtttrs` and `strictDeps` attributes ``                                       |
| [`3997b2ad`](https://github.com/NixOS/nixpkgs/commit/3997b2ad7184bc63afffbb56a91268c6723af17e) | `` monodraw: add `__structuredAtttrs` and `strictDeps` attributes ``                                     |
| [`8e7f5571`](https://github.com/NixOS/nixpkgs/commit/8e7f557105b98c8a231538fedaf8b4179d7f7074) | `` lunar: 6.9.7 -> 6.11.0 ``                                                                             |
| [`37e9a5d7`](https://github.com/NixOS/nixpkgs/commit/37e9a5d7d47e99de3d824329a8b0538f81b9abd7) | `` meetingbar: 4.11.6 -> 5.0.0 ``                                                                        |
| [`cc293a81`](https://github.com/NixOS/nixpkgs/commit/cc293a8133b9b7af1ff62eb2389bde9f4bea4086) | `` home-assistant-matter-hub: 2.0.52 -> 2.0.54 ``                                                        |
| [`236d2839`](https://github.com/NixOS/nixpkgs/commit/236d2839b56de51674a416cce75f742708105f4e) | `` yaziPlugins.yamb: init at 0-unstable-2026-08-11 ``                                                    |
| [`b88ffd60`](https://github.com/NixOS/nixpkgs/commit/b88ffd602592d235b96835d2e1b0ffb3358e439e) | `` emacs31: backport ACE mitigation for bug#80574 ``                                                     |
| [`75a58963`](https://github.com/NixOS/nixpkgs/commit/75a58963931318c858fe9d272132a07e61e82997) | `` capnproto-rust: 0.26.0 -> 0.27.0 ``                                                                   |
| [`6b7b2ab4`](https://github.com/NixOS/nixpkgs/commit/6b7b2ab4f53a17c5c953975f1f63012e438a2cd8) | `` emacs30, emacs30-macport: backport ACE mitigation for bug#80574 ``                                    |
| [`00c41737`](https://github.com/NixOS/nixpkgs/commit/00c41737532737909a6867836fd8eaf5d6b9faf1) | `` resvg: update license ``                                                                              |
| [`b535b1f8`](https://github.com/NixOS/nixpkgs/commit/b535b1f87e3a999c361ac6ece7883043ea3fd384) | `` resvg: adopt ``                                                                                       |
| [`4da4ac3a`](https://github.com/NixOS/nixpkgs/commit/4da4ac3a0ba13b009664c42778a9473e219651b8) | `` libnfc-nci: 2.4.1-unstable-2024-08-05 -> 2.4.1-unstable-2026-08-11 ``                                 |
| [`9cb21fa7`](https://github.com/NixOS/nixpkgs/commit/9cb21fa778ab0431a64bd55c133b01b8b339196f) | `` sgdboop: 1.4.2 -> 1.4.3 ``                                                                            |
| [`23756982`](https://github.com/NixOS/nixpkgs/commit/237569823e2d32840cc6d040b466309e939889ba) | `` libsidplayfp: 3.0.2 -> 3.1.0 ``                                                                       |
| [`f864db4f`](https://github.com/NixOS/nixpkgs/commit/f864db4fe7700a76c38e75809b7b82b3d2d538e6) | `` libretro.mupen64plus: 0-unstable-2026-05-20 -> 0-unstable-2026-08-06 ``                               |
| [`944d11db`](https://github.com/NixOS/nixpkgs/commit/944d11db7ca87fbfc8f4925a4b5b0be7af4b69d4) | `` python3Packages.executorch: 1.3.1 -> 1.4.0 ``                                                         |
| [`d58d9e17`](https://github.com/NixOS/nixpkgs/commit/d58d9e172e046c217a4ea661e07ee98e197b6099) | `` dm-mono: use installFonts ``                                                                          |
| [`c0b7ad64`](https://github.com/NixOS/nixpkgs/commit/c0b7ad64de05ded1955b42a530414737349e891a) | `` terraform-providers.metio_migadu: 2026.7.23 -> 2026.8.6 ``                                            |
| [`7535dbcd`](https://github.com/NixOS/nixpkgs/commit/7535dbcd10ea4a55769e8a42a02d48fea6a5743b) | `` prettier-plugin-tailwindcss: init at 0.8.1 ``                                                         |
| [`c924a09a`](https://github.com/NixOS/nixpkgs/commit/c924a09ab314c062f31a0929b50574028e24be4d) | `` gpauth: 2.6.4 -> 2.6.5 ``                                                                             |
| [`8348017c`](https://github.com/NixOS/nixpkgs/commit/8348017c6890bf138adfa701c35bd10cdfc80e38) | `` toppler: drop ``                                                                                      |
| [`126b4b04`](https://github.com/NixOS/nixpkgs/commit/126b4b0427e237d6542bb28ef254cbb30afc1b04) | `` zchunk: 1.5.3 -> 1.5.4 ``                                                                             |

*... and 1722 more commits (truncated)*